### PR TITLE
Allow disabling TTL termination

### DIFF
--- a/pouta_blueprints/tasks.py
+++ b/pouta_blueprints/tasks.py
@@ -47,7 +47,7 @@ def deprovision_expired():
 
         if not instance.get('state') in ['running']:
             continue
-        if not instance.get('lifetime_left'):
+        if not instance.get('lifetime_left') and instance.get('max_lifetime'):
             logger.info('timed deprovisioning triggered for %s' % instance.get('id'))
             run_deprovisioning.delay(token, instance.get('id'))
 

--- a/pouta_blueprints/views.py
+++ b/pouta_blueprints/views.py
@@ -324,6 +324,7 @@ instance_fields = {
     'name': fields.String,
     'provisioned_at': fields.DateTime,
     'lifetime_left': fields.Integer,
+    'max_lifetime': fields.Integer,
     'state': fields.String,
     'error_msg': fields.String,
     'user_id': fields.String,
@@ -364,6 +365,7 @@ class InstanceList(restful.Resource):
             if instance.provisioned_at:
                 age = (datetime.datetime.utcnow() - instance.provisioned_at).total_seconds()
             instance.lifetime_left = max(blueprint.max_lifetime - age, 0)
+            instance.max_lifetime = blueprint.max_lifetime
 
         return instances
 
@@ -430,15 +432,16 @@ class InstanceView(restful.Resource):
         else:
             instance.user_id = user.visual_id
 
-        res_parent = Blueprint.query.filter_by(id=instance.blueprint_id).first()
-        instance.blueprint_id = res_parent.visual_id
+        blueprint = Blueprint.query.filter_by(id=instance.blueprint_id).first()
+        instance.blueprint_id = blueprint.visual_id
 
         instance.logs = InstanceLogs.get_logfile_urls(instance.visual_id)
 
         age = 0
         if instance.provisioned_at:
             age = (datetime.datetime.utcnow() - instance.provisioned_at).total_seconds()
-        instance.lifetime_left = max(res_parent.max_lifetime - age, 0)
+        instance.lifetime_left = max(blueprint.max_lifetime - age, 0)
+        instance.max_lifetime = blueprint.max_lifetime
 
         return instance
 


### PR DESCRIPTION
User can set the max_lifetime value of a blueprint to value 0 when TTL
termination is not desired.

Fixes #73
