### PR TITLE
Fixed Ansible provisioning

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -3,8 +3,12 @@
             dest=/etc/apt/sources.list
             backup=yes
 
-- name: refresh repository metadata
-  apt: update_cache=yes
+
+- name: refresh repository metadata install python-apt
+  raw: apt-get update
+
+- name: install python-apt
+  raw: apt-get install python-apt -y -q
 
 - name: tools for debugging installation
   apt: pkg={{item}} state=present

--- a/ansible/roles/docker_host/main.yml
+++ b/ansible/roles/docker_host/main.yml
@@ -28,12 +28,6 @@
       with_items:
         - ansible
 
-    - name: Install docker-py from pip (required by ansible, not available for Trusty as apt package)
-      pip: name={{ item }}
-      with_items:
-        - docker-py
-        - ansible
-
     - name: Add cloud-user to docker group and create ssh key
       user:
         name=cloud-user

--- a/ansible/roles/docker_host/main.yml
+++ b/ansible/roles/docker_host/main.yml
@@ -20,6 +20,14 @@
         - build-essential
         - python-dev
 
+    - name: Install docker-py from pip (required by ansible, not available for Trusty as apt package, fixed version due to recent backward incompatible upgrade)
+      pip: name=docker-py version=1.1.0
+
+    - name: Install packages from pip
+      pip: name={{ item }}
+      with_items:
+        - ansible
+
     - name: Install docker-py from pip (required by ansible, not available for Trusty as apt package)
       pip: name={{ item }}
       with_items:


### PR DESCRIPTION
Due to recent backward incompatible upgrade of docker-py
- added fixed version of docker-py until the issue with undefined constant is fixed with ansible

Package python-apt missing on docker containers, cannot use Ansible module apt.
Falling back to use raw calls for apt-get
