### PR TITLE
Refactored Haka/Shibboleth login attributes

### DIFF
--- a/pouta_blueprints/app.py
+++ b/pouta_blueprints/app.py
@@ -25,9 +25,8 @@ app.config.from_object(app.dynamic_config)
 
 if app.config['ENABLE_SHIBBOLETH_LOGIN']:
     SSO_ATTRIBUTE_MAP = {
-        "HTTP_AJP_SHIB_UID": (True, "uid"),
-        "HTTP_AJP_SHIB_MAIL": (True, "mail"),
-        "HTTP_AJP_SHIB_DISPLAYNAME": (False, "name")
+        "HTTP_AJP_SHIB_MAIL": (False, "mail"),
+        "HTTP_AJP_SHIB_SCOPED_EPPN": (True, "eppn"),
     }
     app.config.setdefault('SSO_ATTRIBUTE_MAP', SSO_ATTRIBUTE_MAP)
     app.config.setdefault('SSO_LOGIN_URL', '/login')


### PR DESCRIPTION
Use EPPN for user identification, mail is an optional parameter not used yet,
i.e. it's not atm. guaranteed that mail delivery will work if user login with
Shibboleth. Then again, nothing guarantees that the mail attribute has a valid
value even if it exists.

Opened issue #264 for this redesign
