### PR TITLE
Simplify instance name generation

### DIFF
--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -224,13 +224,13 @@ class Instance(db.Model):
     error_msg = db.Column(db.String(256))
     _instance_data = db.Column('instance_data', db.Text)
 
-    def __init__(self, blueprint, user):
+    def __init__(self, blueprint, user, name_prefix='pb-'):
         self.id = uuid.uuid4().hex
         self.blueprint_id = blueprint.id
         self.blueprint = blueprint
         self.user_id = user.id
         self.state = 'starting'
-        self.name = Instance.generate_name(prefix=app.dynamic_config.get('INSTANCE_NAME_PREFIX'))
+        self.name = Instance.generate_name(name_prefix)
 
     def credits_spent(self, duration=None):
         if self.errored:

--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -214,7 +214,7 @@ class Instance(db.Model):
     id = db.Column(db.String(32), primary_key=True)
     user_id = db.Column(db.String(32), db.ForeignKey('users.id'))
     blueprint_id = db.Column(db.String(32), db.ForeignKey('blueprints.id'))
-    name = db.Column(db.String(64), unique=True)
+    name = db.Column(db.String(64))
     public_ip = db.Column(db.String(64))
     client_ip = db.Column(db.String(64))
     provisioned_at = db.Column(db.DateTime)
@@ -230,6 +230,7 @@ class Instance(db.Model):
         self.blueprint = blueprint
         self.user_id = user.id
         self.state = 'starting'
+        self.name = Instance.generate_name(prefix=app.dynamic_config.get('INSTANCE_NAME_PREFIX'))
 
     def credits_spent(self, duration=None):
         if self.errored:

--- a/pouta_blueprints/views/instances.py
+++ b/pouta_blueprints/views/instances.py
@@ -117,15 +117,6 @@ class InstanceList(restful.Resource):
             return {'error': 'BLUEPRINT_INSTANCE_LIMIT_REACHED'}, 409
 
         instance = Instance(blueprint, user)
-        # XXX: Choosing the name should be done in the model's constructor method
-        # decide on a name that is not used currently
-        existing_names = Instance.query.with_entities(Instance.name).all()
-        # Note: the potential race is solved by unique constraint in database
-        while True:
-            c_name = Instance.generate_name(prefix=app.dynamic_config.get('INSTANCE_NAME_PREFIX'))
-            if c_name not in existing_names:
-                instance.name = c_name
-                break
         token = SystemToken('provisioning')
         db.session.add(instance)
         db.session.add(token)

--- a/pouta_blueprints/views/instances.py
+++ b/pouta_blueprints/views/instances.py
@@ -116,7 +116,7 @@ class InstanceList(restful.Resource):
         if instances_for_user and len(instances_for_user) >= user_instance_limit:
             return {'error': 'BLUEPRINT_INSTANCE_LIMIT_REACHED'}, 409
 
-        instance = Instance(blueprint, user)
+        instance = Instance(blueprint, user, name_prefix=app.dynamic_config.get('INSTANCE_NAME_PREFIX'))
         token = SystemToken('provisioning')
         db.session.add(instance)
         db.session.add(token)


### PR DESCRIPTION
Set instance name within the constructor. As a fully cosmetic thing, instance
name generation should not complicate view logic too much.
