### PR TITLE
Restart celery workers after 10 processed tasks

### DIFF
--- a/ansible/roles/proxy/templates/etc/supervisor/conf.d/nginx_proxy.conf.j2
+++ b/ansible/roles/proxy/templates/etc/supervisor/conf.d/nginx_proxy.conf.j2
@@ -15,8 +15,9 @@ command = {{ virtualenv_path }}/bin/celery worker
     -A pouta_blueprints.tasks
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
-    -Q proxy_tasks
     --concurrency=1
+    --maxtasksperchild=10
+    -Q proxy_tasks
 directory = {{ application_path }}
 user = {{ application_user }}
 stdout_logfile = {{ celery_log_file }}

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/system-worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/system-worker.conf.j2
@@ -5,6 +5,7 @@ command = {{ virtualenv_path }}/bin/celery worker
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=4
+    --maxtasksperchild=10
     -Q system_tasks
 directory = {{ application_path }}
 user = {{ application_user }}

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/worker.conf.j2
@@ -5,6 +5,7 @@ command = {{ virtualenv_path }}/bin/celery worker
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=16
+    --maxtasksperchild=10
     -Q celery
 directory = {{ application_path }}
 user = {{ application_user }}


### PR DESCRIPTION
Automatic restart of celery workers to be on the safe side when running for long periods.

fixes #263 
