### PR TITLE
Refactor/instance state

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -79,6 +79,9 @@ apache_server_admin_email: "admin@example.org"
 gunicorn_num_workers: "{{ 2 * ansible_processor_vcpus }}"
 gunicorn_max_requests: 50
 
+# provisioning workers
+provisioning_num_workers: "{{ 4 * ansible_processor_vcpus }}"
+
 # pouta-virtualcluster
 pvc_install_dir: "/opt/pvc"
 #pvc_version: HEAD

--- a/ansible/roles/common/templates/etc/pouta_blueprints/app_config.j2
+++ b/ansible/roles/common/templates/etc/pouta_blueprints/app_config.j2
@@ -15,3 +15,4 @@ INTERNAL_HTTP_PROXY_PORT: {{ internal_http_proxy_port }}
 {% if enable_shibboleth %}
 ENABLE_SHIBBOLETH_LOGIN: True
 {% endif %}
+PROVISIONING_NUM_WORKERS: {{ provisioning_num_workers }}

--- a/ansible/roles/proxy/templates/etc/supervisor/conf.d/nginx_proxy.conf.j2
+++ b/ansible/roles/proxy/templates/etc/supervisor/conf.d/nginx_proxy.conf.j2
@@ -16,7 +16,7 @@ command = {{ virtualenv_path }}/bin/celery worker
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=1
-    --maxtasksperchild=10
+    --maxtasksperchild=50
     -Q proxy_tasks
 directory = {{ application_path }}
 user = {{ application_user }}

--- a/ansible/roles/worker/tasks/setup_supervisor_config.yml
+++ b/ansible/roles/worker/tasks/setup_supervisor_config.yml
@@ -1,8 +1,10 @@
 ---
-- name: Create the Supervisor config file for user tasks
-  template: src=etc/supervisor/conf.d/worker.conf.j2
-            dest=/etc/supervisor/conf.d/{{ application_name }}-worker.conf
-            backup=yes
+- name: Create the Supervisor config file for provisioning tasks
+  template:
+      src=etc/supervisor/conf.d/provisioning-worker.conf.j2
+      dest=/etc/supervisor/conf.d/{{ application_name }}-provisioning-worker-{{ item }}.conf
+      backup=yes
+  with_sequence: count={{ provisioning_num_workers }}
 
 - name: Create the Supervisor config file for system tasks
   template: src=etc/supervisor/conf.d/system-worker.conf.j2

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/provisioning-worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/provisioning-worker.conf.j2
@@ -1,12 +1,12 @@
-[program:{{ application_name }}-worker]
+[program:{{ application_name }}-worker-{{ item }}]
 command = {{ virtualenv_path }}/bin/celery worker
-    -n worker
+    -n provisioning-worker-{{ item }}
     -A pouta_blueprints.tasks
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
-    --concurrency=4
+    --concurrency=1
     --maxtasksperchild=50
-    -Q celery
+    -Q provisioning_tasks-{{ item }}
 directory = {{ application_path }}
 user = {{ application_user }}
 stdout_logfile = {{ celery_log_file }}

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/system-worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/system-worker.conf.j2
@@ -5,7 +5,7 @@ command = {{ virtualenv_path }}/bin/celery worker
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=4
-    --maxtasksperchild=10
+    --maxtasksperchild=50
     -Q system_tasks
 directory = {{ application_path }}
 user = {{ application_user }}

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/worker.conf.j2
@@ -4,8 +4,8 @@ command = {{ virtualenv_path }}/bin/celery worker
     -A pouta_blueprints.tasks
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
-    --concurrency=16
-    --maxtasksperchild=10
+    --concurrency=4
+    --maxtasksperchild=50
     -Q celery
 directory = {{ application_path }}
 user = {{ application_user }}

--- a/pouta_blueprints/client.py
+++ b/pouta_blueprints/client.py
@@ -24,7 +24,7 @@ class PBClient(object):
         resp = requests.patch(url, data=payload, headers=headers, verify=self.ssl_verify)
         return resp
 
-    def do_put(self, object_url, payload):
+    def do_put(self, object_url, payload=None):
         headers = {'Content-type': 'application/x-www-form-urlencoded',
                    'Accept': 'text/plain',
                    'Authorization': 'Basic %s' % self.auth}
@@ -89,7 +89,7 @@ class PBClient(object):
         return resp.json()
 
     def obtain_lock(self, lock_id):
-        resp = self.do_put('locks/%s' % lock_id, {})
+        resp = self.do_put('locks/%s' % lock_id)
         if resp.status_code == 200:
             return lock_id
         elif resp.status_code == 409:
@@ -101,7 +101,5 @@ class PBClient(object):
         resp = self.do_delete('locks/%s' % lock_id)
         if resp.status_code == 200:
             return lock_id
-        elif resp.status_code == 409:
-            return None
         else:
             raise RuntimeError('Error deleting lock: %s, %s' % (lock_id, resp.reason))

--- a/pouta_blueprints/config.py
+++ b/pouta_blueprints/config.py
@@ -87,6 +87,8 @@ class BaseConfig(object):
     PUBLIC_HTTP_PROXY_PORT = 8000
     INTERNAL_HTTP_PROXY_PORT = 8000
 
+    PROVISIONING_NUM_WORKERS = 1
+
     # enable access by []
     def __getitem__(self, item):
         return getattr(self, item)

--- a/pouta_blueprints/drivers/provisioning/base_driver.py
+++ b/pouta_blueprints/drivers/provisioning/base_driver.py
@@ -70,7 +70,7 @@ class ProvisioningDriverBase(object):
         instance = pbclient.get_instance(instance_id)
         if not instance['to_be_deleted'] and instance['state'] in [Instance.STATE_QUEUEING]:
             self.provision(token, instance_id)
-        elif instance['to_be_deleted']:
+        elif instance['to_be_deleted'] and instance['state'] not in [Instance.STATE_DELETED]:
             self.deprovision(token, instance_id)
         else:
             self.logger.debug("update('%s') - nothing to do for %s" % (instance_id, instance))

--- a/pouta_blueprints/drivers/provisioning/base_driver.py
+++ b/pouta_blueprints/drivers/provisioning/base_driver.py
@@ -63,13 +63,12 @@ class ProvisioningDriverBase(object):
                 {'style': 'btn-info', 'title': 'Create', 'type': 'submit'}
             ], 'model': {}}
 
-
     def update(self, token, instance_id):
         self.logger.debug("update('%s')" % instance_id)
 
         pbclient = PBClient(token, self.config['INTERNAL_API_BASE_URL'], ssl_verify=False)
         instance = pbclient.get_instance(instance_id)
-        if not instance['to_be_deleted'] and instance['state'] in (Instance.STATE_QUEUEING):
+        if not instance['to_be_deleted'] and instance['state'] in [Instance.STATE_QUEUEING]:
             self.provision(token, instance_id)
         elif instance['to_be_deleted']:
             self.deprovision(token, instance_id)

--- a/pouta_blueprints/drivers/provisioning/base_driver.py
+++ b/pouta_blueprints/drivers/provisioning/base_driver.py
@@ -92,10 +92,12 @@ class ProvisioningDriverBase(object):
         try:
             pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_PROVISIONING})
             self.logger.debug('calling subclass do_provision')
-            self.do_provision(token, instance_id)
 
-            self.logger.debug('finishing provisioning')
-            pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_RUNNING})
+            new_state = self.do_provision(token, instance_id)
+            if not new_state:
+                new_state = Instance.STATE_RUNNING
+
+            pbclient.do_instance_patch(instance_id, {'state': new_state})
         except Exception as e:
             self.logger.exception('do_provision raised %s' % e)
             pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_FAILED})

--- a/pouta_blueprints/drivers/provisioning/base_driver.py
+++ b/pouta_blueprints/drivers/provisioning/base_driver.py
@@ -89,9 +89,8 @@ class ProvisioningDriverBase(object):
             self.logger.info('could not obtain lock on %s' % lock_id)
             return
 
-        pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_PROVISIONING})
-
         try:
+            pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_PROVISIONING})
             self.logger.debug('calling subclass do_provision')
             self.do_provision(token, instance_id)
 
@@ -114,8 +113,8 @@ class ProvisioningDriverBase(object):
             self.logger.info('could not obtain lock on %s' % lock_id)
             return
 
-        pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_DELETING})
         try:
+            pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_DELETING})
             self.logger.debug('calling subclass do_deprovision')
             self.do_deprovision(token, instance_id)
 

--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -10,6 +10,7 @@ from requests.exceptions import ReadTimeout
 from pouta_blueprints.client import PBClient
 from pouta_blueprints.drivers.provisioning import base_driver
 import docker
+from pouta_blueprints.models import Instance
 from pouta_blueprints.services.openstack_service import OpenStackService
 import pouta_blueprints.tasks
 from lockfile import locked, LockTimeout
@@ -286,7 +287,7 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
         except KeyError:
             self.logger.info("do_deprovision: No proxy route in instance data for %s" % instance_id)
 
-        if instance['state'] == 'deleted':
+        if instance['state'] == Instance.STATE_DELETED:
             self.logger.debug("do_deprovision: instance already deleted %s" % instance_id)
             return
 

--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -182,10 +182,11 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
 
             try:
                 self._do_provision(token, instance_id, int(time.time()))
+                return Instance.STATE_RUNNING
             except (RuntimeWarning, ConnectionError) as e:
                 self.logger.info('_do_provision() failed for %s due to %s' % (instance_id, e))
                 log_uploader.info("provisioning failed, queueing again to retry\n")
-                pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_QUEUEING})
+                return Instance.STATE_QUEUEING
         finally:
             pbclient.release_lock(lock_id)
 

--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -184,7 +184,7 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
                 self._do_provision(token, instance_id, int(time.time()))
             except (RuntimeWarning, ConnectionError) as e:
                 self.logger.info('_do_provision() failed for %s due to %s' % (instance_id, e))
-                log_uploader.info("provisioning failed, queueing again to retry")
+                log_uploader.info("provisioning failed, queueing again to retry\n")
                 pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_QUEUEING})
         finally:
             pbclient.release_lock(lock_id)
@@ -308,7 +308,6 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
 
         try:
             docker_url = instance['instance_data']['docker_url']
-            docker_host_id = instance['instance_data']['docker_host_id']
         except KeyError:
             self.logger.info('no docker url for instance %s, assuming provisioning has failed' % instance_id)
             return
@@ -325,6 +324,9 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
                 self.logger.info('no container found for instance %s, assuming already deleted' % instance_id)
             else:
                 raise e
+        except ConnectionError as e:
+            self.logger.info('no host found for instance %s, assuming already deleted, exception: %s' %
+                             (instance_id, e))
 
         self.logger.debug("do_deprovision done for %s" % instance_id)
 

--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -204,11 +204,13 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
         blueprint_config = blueprint['config']
 
         log_uploader.info("selecting host...")
-        docker_host = self._select_host(blueprint_config['consumed_slots'], cur_ts)
+
+        docker_hosts = self._select_hosts(blueprint_config['consumed_slots'], cur_ts)
+        selected_host = docker_hosts[0]
+
+        docker_client = ap.get_docker_client(selected_host['docker_url'])
 
         log_uploader.info("done\n")
-
-        docker_client = ap.get_docker_client(docker_host['docker_url'])
 
         container_name = instance['name']
 
@@ -253,8 +255,8 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
                     )
                 },
             ],
-            'docker_url': docker_host['docker_url'],
-            'docker_host_id': docker_host['id'],
+            'docker_url': selected_host['docker_url'],
+            'docker_host_id': selected_host['id'],
             'proxy_route': proxy_route,
         }
 
@@ -267,13 +269,14 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
         )
 
         log_uploader.info("adding route\n")
-        ap.proxy_add_route(proxy_route, 'http://%s:%s' % (docker_host['private_ip'], public_port))
+        ap.proxy_add_route(proxy_route, 'http://%s:%s' % (selected_host['private_ip'], public_port))
 
         log_uploader.info("provisioning done for %s\n" % instance_id)
 
     def do_deprovision(self, token, instance_id):
         ap = self._get_ap()
         pbclient = ap.get_pb_client(token, self.config['INTERNAL_API_BASE_URL'], ssl_verify=False)
+
         lock_id = 'dd_host:%s' % 'global'
         try:
             lock_res = pbclient.obtain_lock(lock_id)
@@ -501,33 +504,31 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
             host['lifetime_left'] = lifetime
             self.logger.debug('do_housekeep(): host %s has lifetime %d' % (host['id'], lifetime))
 
-    def _select_host(self, slots, cur_ts):
+    def _select_hosts(self, slots, cur_ts):
         hosts = self._get_hosts(cur_ts)
         active_hosts = self.get_active_hosts(hosts)
 
         # first try to use the oldest active host with space and lifetime left
         active_hosts = sorted(active_hosts, key=lambda entry: entry['spawn_ts'])
-        selected_host = None
+        selected_hosts = []
         for host in active_hosts:
             is_fresh = host['lifetime_left'] > DD_HOST_LIFETIME_LOW
             has_enough_slots = host['num_slots'] - host['num_reserved_slots'] >= slots
             if is_fresh and has_enough_slots:
-                selected_host = host
-                break
-        if not selected_host:
+                selected_hosts.append(host)
+        if len(selected_hosts) == 0:
             # try to use any active host with space
             for host in active_hosts:
                 if host['num_slots'] - host['num_reserved_slots'] >= slots:
-                    selected_host = host
-                    break
+                    selected_hosts.append(host)
 
-        if not selected_host:
+        if len(selected_hosts) == 0:
             self.logger.debug('_select_host(): no space left, %d slots requested,'
                               ' active hosts: %s' % (slots, active_hosts))
             raise RuntimeWarning('_select_host(): no space left for requested %d slots' % slots)
 
-        self.logger.debug("_select_host(): %d total active, selected %s" % (len(active_hosts), selected_host))
-        return selected_host
+        self.logger.debug("_select_host(): %d total active, %d available" % (len(active_hosts), len(selected_hosts)))
+        return selected_hosts
 
     def _get_hosts(self, cur_ts):
         ap = self._get_ap()
@@ -563,7 +564,6 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
 
         return hosts
 
-    @locked('%s/docker_driver_host_state' % DD_RUNTIME_PATH)
     def _save_host_state(self, hosts, cur_ts):
         ap = self._get_ap()
         data_file = '%s/%s' % (self.config['INSTANCE_DATA_DIR'], 'docker_driver.json')

--- a/pouta_blueprints/drivers/provisioning/docker_driver_config.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver_config.py
@@ -23,7 +23,7 @@ CONFIG = {
             },
             'memory_limit': {
                 'type': 'string',
-                'default': '256m',
+                'default': '512m',
             },
             'consumed_slots': {
                 'type': 'integer',

--- a/pouta_blueprints/drivers/provisioning/openstack_driver.py
+++ b/pouta_blueprints/drivers/provisioning/openstack_driver.py
@@ -6,6 +6,7 @@ import novaclient
 
 from pouta_blueprints.drivers.provisioning import base_driver
 from pouta_blueprints.client import PBClient
+from pouta_blueprints.models import Instance
 
 SLEEP_BETWEEN_POLLS = 3
 POLL_MAX_WAIT = 180
@@ -89,7 +90,7 @@ class OpenStackDriver(base_driver.ProvisioningDriverBase):
         key_data = pbclient.get_user_key_data(instance_user).json()
         if not key_data:
             error = 'user\'s public key is missing'
-            error_body = {'state': 'failed', 'error_msg': error}
+            error_body = {'state': Instance.STATE_FAILED, 'error_msg': error}
             pbclient.do_instance_patch(instance_id, error_body)
             self.logger.debug(error)
             raise RuntimeError(error)

--- a/pouta_blueprints/drivers/provisioning/pvc_cmdline_driver.py
+++ b/pouta_blueprints/drivers/provisioning/pvc_cmdline_driver.py
@@ -9,6 +9,7 @@ import stat
 
 from pouta_blueprints.drivers.provisioning import base_driver
 from pouta_blueprints.client import PBClient
+from pouta_blueprints.models import Instance
 
 
 class PvcCmdLineDriver(base_driver.ProvisioningDriverBase):
@@ -105,7 +106,7 @@ class PvcCmdLineDriver(base_driver.ProvisioningDriverBase):
         key_data = pbclient.get_user_key_data(instance['user_id']).json()
         user_key_file = '%s/userkey.pub' % instance_dir
         if not key_data:
-            pbclient.do_instance_patch(instance_id, {'state': 'failed'})
+            pbclient.do_instance_patch(instance_id, {'state': Instance.STATE_FAILED})
             raise RuntimeError("User's public key missing")
 
         with open(user_key_file, 'w') as kf:

--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -237,6 +237,23 @@ class Blueprint(db.Model):
 
 
 class Instance(db.Model):
+
+    STATE_QUEUEING = 'queueing'
+    STATE_PROVISIONING = 'provisioning'
+    STATE_RUNNING = 'running'
+    STATE_DELETING = 'deleting'
+    STATE_DELETED = 'deleted'
+    STATE_FAILED = 'failed'
+
+    VALID_STATES = [
+        STATE_QUEUEING,
+        STATE_PROVISIONING,
+        STATE_RUNNING,
+        STATE_DELETING,
+        STATE_DELETED,
+        STATE_FAILED,
+    ]
+
     __tablename__ = 'instances'
     id = db.Column(db.String(32), primary_key=True)
     user_id = db.Column(db.String(32), db.ForeignKey('users.id'))
@@ -248,6 +265,7 @@ class Instance(db.Model):
     deprovisioned_at = db.Column(db.DateTime)
     errored = db.Column(db.Boolean, default=False)
     state = db.Column(db.String(32))
+    to_be_deleted = db.Column(db.Boolean, default=False)
     error_msg = db.Column(db.String(256))
     _instance_data = db.Column('instance_data', db.Text)
 
@@ -256,7 +274,7 @@ class Instance(db.Model):
         self.blueprint_id = blueprint.id
         self.blueprint = blueprint
         self.user_id = user.id
-        self.state = 'starting'
+        self.state = Instance.STATE_QUEUEING
 
     def credits_spent(self, duration=None):
         if self.errored:

--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -427,7 +427,7 @@ class Variable(db.Model):
 
     filtered_variables = (
         'SECRET_KEY', 'INTERNAL_API_BASE_URL', 'SQLALCHEMY_DATABASE_URI', 'WTF_CSRF_ENABLED',
-        'MESSAGE_QUEUE_URI', 'SSL_VERIFY', 'ENABLE_SHIBBOLETH_LOGIN')
+        'MESSAGE_QUEUE_URI', 'SSL_VERIFY', 'ENABLE_SHIBBOLETH_LOGIN', 'PROVISIONING_NUM_WORKERS')
 
     id = db.Column(db.String(32), primary_key=True)
     key = db.Column(db.String(MAX_VARIABLE_KEY_LENGTH), unique=True)

--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -237,7 +237,6 @@ class Blueprint(db.Model):
 
 
 class Instance(db.Model):
-
     STATE_QUEUEING = 'queueing'
     STATE_PROVISIONING = 'provisioning'
     STATE_RUNNING = 'running'

--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -244,14 +244,14 @@ class Instance(db.Model):
     STATE_DELETED = 'deleted'
     STATE_FAILED = 'failed'
 
-    VALID_STATES = [
+    VALID_STATES = (
         STATE_QUEUEING,
         STATE_PROVISIONING,
         STATE_RUNNING,
         STATE_DELETING,
         STATE_DELETED,
         STATE_FAILED,
-    ]
+    )
 
     __tablename__ = 'instances'
     id = db.Column(db.String(32), primary_key=True)

--- a/pouta_blueprints/server.py
+++ b/pouta_blueprints/server.py
@@ -54,7 +54,11 @@ api.add_resource(PublicVariableList, api_root + '/config')
 api.add_resource(WhatIsMyIp, api_root + '/what_is_my_ip', methods=['GET'])
 api.add_resource(Quota, api_root + '/quota')
 api.add_resource(UserQuota, api_root + '/quota/<string:user_id>')
-api.add_resource(LockView, api_root + '/locks/<string:lock_id>')
+api.add_resource(
+    LockView,
+    api_root + '/locks/<string:lock_id>',
+    methods=['PUT', 'DELETE']
+)
 
 app.register_blueprint(blueprints)
 app.register_blueprint(plugins)

--- a/pouta_blueprints/server.py
+++ b/pouta_blueprints/server.py
@@ -51,14 +51,10 @@ api.add_resource(PluginView, api_root + '/plugins/<string:plugin_id>')
 api.add_resource(VariableList, api_root + '/variables')
 api.add_resource(VariableView, api_root + '/variables/<string:variable_id>')
 api.add_resource(PublicVariableList, api_root + '/config')
-api.add_resource(WhatIsMyIp, api_root + '/what_is_my_ip', methods=['GET'])
+api.add_resource(WhatIsMyIp, api_root + '/what_is_my_ip')
 api.add_resource(Quota, api_root + '/quota')
 api.add_resource(UserQuota, api_root + '/quota/<string:user_id>')
-api.add_resource(
-    LockView,
-    api_root + '/locks/<string:lock_id>',
-    methods=['PUT', 'DELETE']
-)
+api.add_resource(LockView, api_root + '/locks/<string:lock_id>')
 
 app.register_blueprint(blueprints)
 app.register_blueprint(plugins)

--- a/pouta_blueprints/static/js/controllers/DashboardController.js
+++ b/pouta_blueprints/static/js/controllers/DashboardController.js
@@ -48,7 +48,7 @@ app.controller('DashboardController', ['$q', '$scope', '$interval', 'AuthService
         };
 
         $scope.deprovision = function (instance) {
-            instance.state = 'deprovisioning';
+            instance.state = 'deleting';
             instance.error_msg = '';
             instance.remove();
         };

--- a/pouta_blueprints/tasks.py
+++ b/pouta_blueprints/tasks.py
@@ -124,28 +124,37 @@ def periodic_update():
     pbclient = PBClient(token, flask_config['INTERNAL_API_BASE_URL'], ssl_verify=False)
     instances = pbclient.get_instances()
 
-    # do not spam more than 10 updates at one interval
-    if len(instances) > 10:
-        instances = random.sample(instances, 10)
-
+    deprovision_list = []
+    update_list = []
     for instance in instances:
         logger.debug('checking instance for actions %s' % instance['name'])
         deprovision_required = False
         if instance.get('state') in [Instance.STATE_RUNNING]:
             if not instance.get('lifetime_left') and instance.get('maximum_lifetime'):
-                logger.info('deprovisioning triggered for %s (reason: maximum lifetime exceeded)' % instance.get('id'))
                 deprovision_required = True
 
             if deprovision_required:
-                pbclient.do_instance_patch(instance['id'], {'to_be_deleted': True})
-                run_update.apply_async(
-                    args=[token, instance.get('id')],
-                    queue='system_tasks',
-                )
+                deprovision_list.append(instance)
+
         elif instance.get('state') not in [Instance.STATE_FAILED]:
-                run_update.apply_async(
-                    args=[token, instance.get('id')]
-                )
+            update_list.append(instance)
+
+    if len(deprovision_list) > 10:
+        deprovision_list = random.sample(deprovision_list, 10)
+    for instance in deprovision_list:
+        logger.info('deprovisioning triggered for %s (reason: maximum lifetime exceeded)' % instance.get('id'))
+        pbclient.do_instance_patch(instance['id'], {'to_be_deleted': True})
+        run_update.apply_async(
+            args=[token, instance.get('id')],
+            queue='system_tasks',
+        )
+
+    if len(update_list) > 10:
+        update_list = random.sample(update_list, 10)
+    for instance in update_list:
+        run_update.apply_async(
+            args=[token, instance.get('id')]
+        )
 
 
 @app.task(name="pouta_blueprints.tasks.send_mails")

--- a/pouta_blueprints/tasks.py
+++ b/pouta_blueprints/tasks.py
@@ -3,6 +3,7 @@ from email.mime.text import MIMEText
 import glob
 import json
 import logging
+import random
 from string import Template
 import os
 import smtplib
@@ -122,6 +123,10 @@ def periodic_update():
     token = get_token()
     pbclient = PBClient(token, flask_config['INTERNAL_API_BASE_URL'], ssl_verify=False)
     instances = pbclient.get_instances()
+
+    # do not spam more than 10 updates at one interval
+    if len(instances) > 10:
+        instances = random.sample(instances, 10)
 
     for instance in instances:
         logger.debug('checking instance for actions %s' % instance['name'])

--- a/pouta_blueprints/tests/test_docker_driver.py
+++ b/pouta_blueprints/tests/test_docker_driver.py
@@ -7,6 +7,7 @@ from pouta_blueprints.drivers.provisioning.docker_driver import DD_STATE_ACTIVE,
 
 import mock
 from sys import version_info
+import docker.utils
 
 if version_info.major == 2:
     import __builtin__ as builtins
@@ -81,6 +82,9 @@ class DockerClientMock(object):
 
         return self._containers[:]
 
+    def create_host_config(self, *args, **kwargs):
+        return docker.utils.create_host_config(*args, **kwargs)
+
     def create_container(self, name, **kwargs):
         if self.failure_mode:
             raise RuntimeError('In failure mode')
@@ -133,6 +137,7 @@ class PBClientMock(object):
                     docker_image='csc/test_image',
                     internal_port=8888,
                     consumed_slots=1,
+                    memory_limit='512m',
                 ),
             )
         }
@@ -248,7 +253,7 @@ class DockerDriverTestCase(BaseTestCase):
         dd = self.create_docker_driver()
         ddam = dd._get_ap()
 
-        # check that a host gets createdDD_CONTAINERS_PER_HOST
+        # check that a host gets created
         cur_ts = 1000000
         dd._do_housekeep(token='foo', cur_ts=cur_ts)
         self.assertEquals(len(ddam.oss_mock.servers), 1)

--- a/pouta_blueprints/tests/test_models.py
+++ b/pouta_blueprints/tests/test_models.py
@@ -51,3 +51,20 @@ class ModelsTestCase(BaseTestCase):
         i1.deprovisioned_at = datetime.datetime(2015, 1, 1, 12, 5)
         expected_cost = (1.5 * 5 * 60 / 3600)
         assert (expected_cost - 0.01) < i1.credits_spent() < (expected_cost + 0.01)
+
+    def test_instance_states(self):
+        i1 = Instance(self.known_blueprint, self.known_user)
+        for state in Instance.VALID_STATES:
+            i1.state = state
+
+        invalid_states = [x + 'foo' for x in Instance.VALID_STATES]
+        invalid_states.append('')
+        invalid_states.extend([x.upper() for x in Instance.VALID_STATES])
+
+        for state in invalid_states:
+            try:
+                i1.state = state
+                self.fail('invalid state %s not detected' % state)
+            except ValueError:
+                pass
+

--- a/pouta_blueprints/tests/test_models.py
+++ b/pouta_blueprints/tests/test_models.py
@@ -67,4 +67,3 @@ class ModelsTestCase(BaseTestCase):
                 self.fail('invalid state %s not detected' % state)
             except ValueError:
                 pass
-

--- a/pouta_blueprints/views/activations.py
+++ b/pouta_blueprints/views/activations.py
@@ -67,4 +67,4 @@ class ActivationList(restful.Resource):
         db.session.add(token)
         db.session.commit()
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            send_mails.delay([(user.email, token.token)])
+            send_mails.apply_async(args=[[(user.email, token.token)]], queue='system_tasks')

--- a/pouta_blueprints/views/commons.py
+++ b/pouta_blueprints/views/commons.py
@@ -79,7 +79,7 @@ def invite_user(email, password=None, is_admin=False):
     db.session.commit()
 
     if not app.dynamic_config['SKIP_TASK_QUEUE'] and not app.dynamic_config['MAIL_SUPPRESS_SEND']:
-        send_mails.delay([(user.email, token.token)])
+        send_mails.apply_async(args=[[(user.email, token.token)]], queue='system_tasks')
     else:
         logging.warn(
             "email sending suppressed in config: SKIP_TASK_QUEUE:%s MAIL_SUPPRESS_SEND:%s" %

--- a/pouta_blueprints/views/instances.py
+++ b/pouta_blueprints/views/instances.py
@@ -187,6 +187,7 @@ class InstanceView(restful.Resource):
         if not instance:
             abort(404)
         instance.to_be_deleted = True
+        instance.state = Instance.STATE_DELETING
         instance.deprovisioned_at = datetime.datetime.utcnow()
         token = SystemToken('provisioning')
         db.session.add(token)

--- a/pouta_blueprints/views/instances.py
+++ b/pouta_blueprints/views/instances.py
@@ -12,7 +12,7 @@ from pouta_blueprints.models import db, Blueprint, Instance, User, SystemToken
 from pouta_blueprints.forms import InstanceForm, UserIPForm
 from pouta_blueprints.server import app, restful
 from pouta_blueprints.utils import requires_admin, memoize
-from pouta_blueprints.tasks import run_provisioning, run_deprovisioning, update_user_connectivity
+from pouta_blueprints.tasks import run_update, update_user_connectivity
 from pouta_blueprints.views.commons import auth
 
 instances = FlaskBlueprint('instances', __name__)
@@ -27,6 +27,7 @@ instance_fields = {
     'maximum_lifetime': fields.Integer,
     'runtime': fields.Float,
     'state': fields.String,
+    'to_be_deleted': fields.Boolean,
     'error_msg': fields.String,
     'username': fields.String,
     'user_id': fields.String,
@@ -56,10 +57,10 @@ class InstanceList(restful.Resource):
     def get(self):
         user = g.user
         if user.is_admin:
-            instances = Instance.query.filter(Instance.state != 'deleted').all()
+            instances = Instance.query.filter(Instance.state != Instance.STATE_DELETED).all()
         else:
             instances = Instance.query.filter_by(user_id=user.id). \
-                filter((Instance.state != 'deleted')).all()
+                filter((Instance.state != Instance.STATE_DELETED)).all()
 
         get_blueprint = memoize(query_blueprint)
         get_user = memoize(query_user)
@@ -133,7 +134,7 @@ class InstanceList(restful.Resource):
         db.session.commit()
 
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            run_provisioning.delay(token.token, instance.id)
+            run_update.delay(token.token, instance.id)
         return marshal(instance, instance_fields), 200
 
 
@@ -145,6 +146,7 @@ class InstanceView(restful.Resource):
     parser.add_argument('error_msg', type=str)
     parser.add_argument('client_ip', type=str)
     parser.add_argument('instance_data', type=str)
+    parser.add_argument('to_be_deleted', type=bool)
 
     @auth.login_required
     @marshal_with(instance_fields)
@@ -184,13 +186,13 @@ class InstanceView(restful.Resource):
         instance = query.first()
         if not instance:
             abort(404)
-        instance.state = 'deleting'
+        instance.to_be_deleted = True
         instance.deprovisioned_at = datetime.datetime.utcnow()
         token = SystemToken('provisioning')
         db.session.add(token)
         db.session.commit()
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            run_deprovisioning.delay(token.token, instance.id)
+            run_update.delay(token.token, instance.id)
 
     @auth.login_required
     def put(self, instance_id):
@@ -225,12 +227,16 @@ class InstanceView(restful.Resource):
 
         if args.get('state'):
             instance.state = args['state']
-            if instance.state == 'running':
+            if instance.state == Instance.STATE_RUNNING:
                 if not instance.provisioned_at:
                     instance.provisioned_at = datetime.datetime.utcnow()
-            if args['state'] == 'failed':
+            if args['state'] == Instance.STATE_FAILED:
                 instance.errored = True
 
+            db.session.commit()
+
+        if args.get('to_be_deleted'):
+            instance.to_be_deleted = args['to_be_deleted']
             db.session.commit()
 
         if args.get('error_msg'):


### PR DESCRIPTION
- instance provisioning state tracked centrally
- instance state strings now defined in Instance class
- requesting instance deletion goes through a separate flag instead of 'deprovisioning' state
- dedicated Celery queues for provisioning workers, worker count based on core count on the host 
- queues for provisioning tasks are selected based on instance id -> order is preserved per instance
- Celery is set to automatically create queues as necessary
