### PR TITLE
Refactor/tasks and celery router#324 v2

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -80,7 +80,7 @@ gunicorn_num_workers: "{{ 2 * ansible_processor_vcpus }}"
 gunicorn_max_requests: 50
 
 # provisioning workers
-provisioning_num_workers: "{{ 4 * ansible_processor_vcpus }}"
+provisioning_num_workers: "{{ 2 if deploy_mode == 'devel' else 4 * ansible_processor_vcpus }}"
 
 # pouta-virtualcluster
 pvc_install_dir: "/opt/pvc"

--- a/ansible/roles/proxy/templates/etc/supervisor/conf.d/nginx_proxy.conf.j2
+++ b/ansible/roles/proxy/templates/etc/supervisor/conf.d/nginx_proxy.conf.j2
@@ -12,7 +12,7 @@ autorestart = true
 
 [program:{{ application_name }}-proxy_worker]
 command = {{ virtualenv_path }}/bin/celery worker
-    -A pouta_blueprints.tasks
+    -A pouta_blueprints.tasks.celery_app
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=1

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/provisioning-worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/provisioning-worker.conf.j2
@@ -1,7 +1,7 @@
 [program:{{ application_name }}-worker-{{ item }}]
 command = {{ virtualenv_path }}/bin/celery worker
     -n provisioning-worker-{{ item }}
-    -A pouta_blueprints.tasks
+    -A pouta_blueprints.tasks.celery_app
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=1

--- a/ansible/roles/worker/templates/etc/supervisor/conf.d/system-worker.conf.j2
+++ b/ansible/roles/worker/templates/etc/supervisor/conf.d/system-worker.conf.j2
@@ -1,7 +1,7 @@
 [program:{{ application_name }}-system-worker]
 command = {{ virtualenv_path }}/bin/celery worker
     -n system-worker
-    -A pouta_blueprints.tasks
+    -A pouta_blueprints.tasks.celery_app
     -Ofair
     --loglevel={{ 'DEBUG' if deploy_mode == 'devel' else 'INFO' }}
     --concurrency=4
@@ -15,7 +15,7 @@ redirect_stderr = true
 
 [program:{{ application_name }}-periodic-worker]
 command = {{ virtualenv_path }}/bin/celery
-    -A pouta_blueprints.tasks beat
+    -A pouta_blueprints.tasks.celery_app beat
     -s {{ runtime_path }}/celerybeat-schedule
     --pidfile {{ runtime_path }}/celerybeat.pid
     -f {{ celerybeat_log_file }}

--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -122,17 +122,11 @@ class DockerDriverAccessProxy(object):
 
     @staticmethod
     def proxy_add_route(route_id, target_url, proxy_no_rewrite):
-        pouta_blueprints.tasks.proxy_add_route.apply_async(
-            args=[route_id, target_url, proxy_no_rewrite],
-            queue='proxy_tasks'
-        )
+        pouta_blueprints.tasks.proxy_add_route.delay(route_id, target_url, proxy_no_rewrite)
 
     @staticmethod
     def proxy_remove_route(route_id):
-        pouta_blueprints.tasks.proxy_remove_route.apply_async(
-            args=[route_id],
-            queue='proxy_tasks'
-        )
+        pouta_blueprints.tasks.proxy_remove_route.delay(route_id)
 
     @staticmethod
     def get_image_names():

--- a/pouta_blueprints/tasks/__init__.py
+++ b/pouta_blueprints/tasks/__init__.py
@@ -1,0 +1,17 @@
+import celery_app
+
+import provisioning_tasks
+import proxy_tasks
+import misc_tasks
+
+run_update = provisioning_tasks.run_update
+
+update_user_connectivity = provisioning_tasks.update_user_connectivity
+
+proxy_add_route = proxy_tasks.proxy_add_route
+
+proxy_remove_route = proxy_tasks.proxy_remove_route
+
+send_mails = misc_tasks.send_mails
+
+periodic_update = misc_tasks.periodic_update

--- a/pouta_blueprints/tasks/celery_app.py
+++ b/pouta_blueprints/tasks/celery_app.py
@@ -1,0 +1,142 @@
+import base64
+import json
+import logging
+
+from celery import Celery
+from kombu import Queue
+from celery.schedules import crontab
+import requests
+from celery.utils.log import get_task_logger
+
+from pouta_blueprints.app import app as _flask_app
+from pouta_blueprints.client import PBClient
+
+flask_app = _flask_app
+flask_config = flask_app.dynamic_config
+
+# tune requests to give less spam in development environment with self signed certificate
+requests.packages.urllib3.disable_warnings()
+logging.getLogger("requests").setLevel(logging.WARNING)
+
+logger = get_task_logger(__name__)
+if flask_config['DEBUG']:
+    logger.setLevel('DEBUG')
+
+
+def get_token():
+    auth_url = '%s/sessions' % flask_config['INTERNAL_API_BASE_URL']
+    auth_credentials = {'email': 'worker@pouta_blueprints',
+                        'password': flask_config['SECRET_KEY']}
+    try:
+        r = requests.post(auth_url, auth_credentials, verify=flask_config['SSL_VERIFY'])
+        return json.loads(r.text).get('token')
+    except:
+        return None
+
+
+def do_get(token, object_url):
+    auth = base64.encodestring('%s:%s' % (token, '')).replace('\n', '')
+    headers = {'Accept': 'text/plain',
+               'Authorization': 'Basic %s' % auth}
+    url = '%s/%s' % (flask_config['INTERNAL_API_BASE_URL'], object_url)
+    resp = requests.get(url, headers=headers, verify=flask_config['SSL_VERIFY'])
+    return resp
+
+
+def do_post(token, api_path, data):
+    auth = base64.encodestring('%s:%s' % (token, '')).replace('\n', '')
+    headers = {'Accept': 'text/plain',
+               'Authorization': 'Basic %s' % auth}
+    url = '%s/%s' % (flask_config['INTERNAL_API_BASE_URL'], api_path)
+    resp = requests.post(url, data, headers=headers, verify=flask_config['SSL_VERIFY'])
+    return resp
+
+
+def get_config():
+    """
+    Retrieve dynamic config over ReST API. Config object from Flask is unable to resolve variables from
+    database if containers are used. In order to use the ReST API some configuration items
+    (Variable.filtered_variables) are required. These are read from Flask config object, as these values
+    cannot be modified during the runtime.
+    """
+    token = get_token()
+    pbclient = PBClient(token, flask_config['INTERNAL_API_BASE_URL'], ssl_verify=False)
+
+    return dict([(x['key'], x['value']) for x in pbclient.do_get('variables').json()])
+
+
+celery_app = Celery(
+    'tasks',
+    broker=flask_config['MESSAGE_QUEUE_URI'],
+    backend=flask_config['MESSAGE_QUEUE_URI']
+)
+
+celery_app.conf.CELERY_TIMEZONE = 'UTC'
+celery_app.conf.CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
+celery_app.conf.CELERYD_PREFETCH_MULTIPLIER = 1
+celery_app.conf.CELERY_TASK_SERIALIZER = 'json'
+
+celery_app.conf.CELERY_CREATE_MISSING_QUEUES = True
+celery_app.conf.CELERY_QUEUES = (
+    Queue('celery', routing_key='task.#'),
+    Queue('proxy_tasks', routing_key='proxy_task.#'),
+    Queue('system_tasks', routing_key='system_task.#'),
+)
+celery_app.conf.CELERY_ROUTES = (
+    'pouta_blueprints.tasks.celery_app.TaskRouter',
+)
+
+celery_app.conf.CELERYBEAT_SCHEDULE = {
+    'periodic-update-every-minute': {
+        'task': 'pouta_blueprints.tasks.periodic_update',
+        'schedule': crontab(minute='*/1'),
+        'options': {'expires': 60, 'queue': 'system_tasks'},
+    },
+    'check-plugins-every-minute': {
+        'task': 'pouta_blueprints.tasks.publish_plugins',
+        'schedule': crontab(minute='*/1'),
+        'options': {'expires': 60, 'queue': 'system_tasks'},
+    },
+    'housekeeping-every-minute': {
+        'task': 'pouta_blueprints.tasks.housekeeping',
+        'schedule': crontab(minute='*/1'),
+        'options': {'expires': 60, 'queue': 'system_tasks'},
+    }
+}
+
+
+class TaskRouter(object):
+    @staticmethod
+    def get_provisioning_queue(instance_id):
+        queue_num = ((int(instance_id[-2:], 16) % flask_config['PROVISIONING_NUM_WORKERS']) + 1)
+        logger.debug('selected queue %d/%d for %s' % (queue_num, flask_config['PROVISIONING_NUM_WORKERS'], instance_id))
+        return 'provisioning_tasks-%d' % queue_num
+
+    def route_for_task(self, task, args=None, kwargs=None):
+        if task in (
+                "pouta_blueprints.tasks.send_mails",
+                "pouta_blueprints.tasks.periodic_update",
+                "pouta_blueprints.tasks.send_mails",
+                "pouta_blueprints.tasks.publish_plugins",
+                "pouta_blueprints.tasks.housekeeping",
+        ):
+            return {'queue': 'system_tasks'}
+
+        if task in (
+                "pouta_blueprints.tasks.update_user_connectivity",
+                "pouta_blueprints.tasks.run_update"
+        ):
+            instance_id = args[0]
+            return {'queue': self.get_provisioning_queue(instance_id)}
+
+        if task == "pouta_blueprints.tasks.run_update":
+            instance_id = args[1]
+            return {'queue': self.get_provisioning_queue(instance_id)}
+
+        if task in (
+                "pouta_blueprints.tasks.proxy_add_route",
+                "pouta_blueprints.tasks.proxy_remove_route"
+        ):
+            return {'queue': 'proxy_tasks'}
+
+        return {'queue': 'celery'}

--- a/pouta_blueprints/tasks/celery_app.py
+++ b/pouta_blueprints/tasks/celery_app.py
@@ -6,6 +6,7 @@ from celery import Celery
 from kombu import Queue
 from celery.schedules import crontab
 import requests
+
 from celery.utils.log import get_task_logger
 
 from pouta_blueprints.app import app as _flask_app

--- a/pouta_blueprints/tasks/misc_tasks.py
+++ b/pouta_blueprints/tasks/misc_tasks.py
@@ -1,0 +1,68 @@
+from email.mime.text import MIMEText
+import random
+import smtplib
+
+from flask import render_template
+
+from pouta_blueprints.client import PBClient
+from pouta_blueprints.models import Instance
+from pouta_blueprints.tasks.celery_app import flask_config, flask_app, logger, get_token, get_config
+from pouta_blueprints.tasks.provisioning_tasks import run_update
+from pouta_blueprints.tasks.celery_app import celery_app
+
+
+@celery_app.task(name="pouta_blueprints.tasks.periodic_update")
+def periodic_update():
+    token = get_token()
+    pbclient = PBClient(token, flask_config['INTERNAL_API_BASE_URL'], ssl_verify=False)
+    instances = pbclient.get_instances()
+
+    deprovision_list = []
+    update_list = []
+    for instance in instances:
+        logger.debug('checking instance for actions %s' % instance['name'])
+        deprovision_required = False
+        if instance.get('state') in [Instance.STATE_RUNNING]:
+            if not instance.get('lifetime_left') and instance.get('maximum_lifetime'):
+                deprovision_required = True
+
+            if deprovision_required:
+                deprovision_list.append(instance)
+
+        elif instance.get('state') not in [Instance.STATE_FAILED]:
+            update_list.append(instance)
+
+    if len(deprovision_list) > 10:
+        deprovision_list = random.sample(deprovision_list, 10)
+    for instance in deprovision_list:
+        logger.info('deprovisioning triggered for %s (reason: maximum lifetime exceeded)' % instance.get('id'))
+        pbclient.do_instance_patch(instance['id'], {'to_be_deleted': True})
+        run_update.delay(instance.get('id'))
+
+    if len(update_list) > 10:
+        update_list = random.sample(update_list, 10)
+    for instance in update_list:
+        run_update.delay(instance.get('id'))
+
+
+@celery_app.task(name="pouta_blueprints.tasks.send_mails")
+def send_mails(users):
+    with flask_app.test_request_context():
+        config = get_config()
+        for email, token in users:
+            base_url = config['BASE_URL'].strip('/')
+            activation_url = '%s/#/activate/%s' % (base_url, token)
+            msg = MIMEText(render_template('invitation.txt', activation_link=activation_url))
+            msg['Subject'] = 'Pouta Blueprints account activation'
+            msg['To'] = email
+            msg['From'] = config['SENDER_EMAIL']
+            logger.info(msg)
+
+            if not config['MAIL_SUPPRESS_SEND']:
+                s = smtplib.SMTP(config['MAIL_SERVER'])
+                if config['MAIL_USE_TLS']:
+                    s.starttls()
+                s.sendmail(msg['From'], [msg['To']], msg.as_string())
+                s.quit()
+            else:
+                logger.info('Mail sending suppressed in config')

--- a/pouta_blueprints/tasks/provisioning_tasks.py
+++ b/pouta_blueprints/tasks/provisioning_tasks.py
@@ -1,0 +1,90 @@
+import json
+
+from pouta_blueprints.client import PBClient
+from pouta_blueprints.tasks.celery_app import get_token, get_config, do_post, flask_config, logger
+from pouta_blueprints.tasks.celery_app import celery_app
+
+def get_provisioning_manager():
+    from stevedore import dispatch
+
+    config = get_config()
+    if config.get('PLUGIN_WHITELIST', ''):
+        plugin_whitelist = config.get('PLUGIN_WHITELIST').split()
+        mgr = dispatch.NameDispatchExtensionManager(
+            namespace='pouta_blueprints.drivers.provisioning',
+            check_func=lambda x: x.name in plugin_whitelist,
+            invoke_on_load=True,
+            invoke_args=(logger, get_config()),
+        )
+    else:
+        mgr = dispatch.NameDispatchExtensionManager(
+            namespace='pouta_blueprints.drivers.provisioning',
+            check_func=lambda x: True,
+            invoke_on_load=True,
+            invoke_args=(logger, get_config()),
+        )
+
+    logger.debug('provisioning manager loaded, extensions: %s ' % mgr.names())
+
+    return mgr
+
+
+def get_provisioning_type(token, instance_id):
+    pbclient = PBClient(token, flask_config['INTERNAL_API_BASE_URL'], ssl_verify=False)
+
+    blueprint = pbclient.get_instance_parent_data(instance_id)
+    plugin_id = blueprint['plugin']
+    return pbclient.get_plugin_data(plugin_id)['name']
+
+
+@celery_app.task(name="pouta_blueprints.tasks.run_update")
+def run_update(instance_id):
+    logger.info('update triggered for %s' % instance_id)
+    token = get_token()
+    mgr = get_provisioning_manager()
+
+    plugin = get_provisioning_type(token, instance_id)
+    mgr.map_method([plugin], 'update', token, instance_id)
+
+    logger.info('update done, notifying server')
+
+
+@celery_app.task(name="pouta_blueprints.tasks.publish_plugins")
+def publish_plugins():
+    logger.info('provisioning plugins queried from worker')
+    token = get_token()
+    mgr = get_provisioning_manager()
+    for plugin in mgr.names():
+        payload = {'plugin': plugin}
+        res = mgr.map_method([plugin], 'get_configuration')
+        if not len(res):
+            logger.warn('plugin returned empty configuration: %s' % plugin)
+            continue
+        config = res[0]
+
+        if not config:
+            logger.warn('No config for %s obtained' % plugin)
+            continue
+
+        for key in ('schema', 'form', 'model'):
+            payload[key] = json.dumps(config.get(key, {}))
+
+        do_post(token, 'plugins', payload)
+
+
+@celery_app.task(name="pouta_blueprints.tasks.housekeeping")
+def housekeeping():
+    token = get_token()
+    logger.info('provisioning plugins queried from worker')
+    mgr = get_provisioning_manager()
+    mgr.map_method(mgr.names(), 'housekeep', token)
+
+
+@celery_app.task(name="pouta_blueprints.tasks.update_user_connectivity")
+def update_user_connectivity(instance_id):
+    logger.info('updating connectivity for instance %s' % instance_id)
+    token = get_token()
+    mgr = get_provisioning_manager()
+    plugin = get_provisioning_type(token, instance_id)
+    mgr.map_method([plugin], 'update_connectivity', token, instance_id)
+    logger.info('update connectivity for instance %s ready' % instance_id)

--- a/pouta_blueprints/tasks/provisioning_tasks.py
+++ b/pouta_blueprints/tasks/provisioning_tasks.py
@@ -4,6 +4,7 @@ from pouta_blueprints.client import PBClient
 from pouta_blueprints.tasks.celery_app import get_token, get_config, do_post, flask_config, logger
 from pouta_blueprints.tasks.celery_app import celery_app
 
+
 def get_provisioning_manager():
     from stevedore import dispatch
 

--- a/pouta_blueprints/tasks/proxy_tasks.py
+++ b/pouta_blueprints/tasks/proxy_tasks.py
@@ -1,0 +1,74 @@
+import glob
+from string import Template
+
+import os
+
+from pouta_blueprints.tasks.celery_app import logger, get_config
+
+from pouta_blueprints.tasks.celery_app import celery_app
+
+RUNTIME_PATH = '/webapps/pouta_blueprints/run'
+
+
+@celery_app.task(name="pouta_blueprints.tasks.proxy_add_route")
+def proxy_add_route(route_key, target):
+    logger.info('proxy_add_route(%s, %s)' % (route_key, target))
+
+    # generate a location snippet for nginx proxy config
+    # see https://support.rstudio.com/hc/en-us/articles/200552326-Running-with-a-Proxy
+    template = Template(
+        """
+        location /${route_key}/ {
+          rewrite ^/${route_key}/(.*)$$ /$$1 break;
+          proxy_pass ${target};
+          proxy_redirect ${target} $$scheme://$$host:${public_http_proxy_port}/${route_key};
+        }
+        """
+    )
+
+    path = '%s/route_key-%s' % (RUNTIME_PATH, route_key)
+    with open(path, 'w') as f:
+        f.write(
+            template.substitute(
+                route_key=route_key,
+                target=target,
+                public_http_proxy_port=get_config()['PUBLIC_HTTP_PROXY_PORT']
+            )
+        )
+
+    refresh_nginx_config()
+
+
+@celery_app.task(name="pouta_blueprints.tasks.proxy_remove_route")
+def proxy_remove_route(route_key):
+    logger.info('proxy_remove_route(%s)' % route_key)
+
+    path = '%s/route_key-%s' % (RUNTIME_PATH, route_key)
+    if os.path.exists(path):
+        os.remove(path)
+    else:
+        logger.info('proxy_remove_route(): no such file')
+
+    refresh_nginx_config()
+
+
+def refresh_nginx_config():
+    config = ['server {', 'listen %s;' % get_config()['INTERNAL_HTTP_PROXY_PORT']]
+
+    nroutes = 0
+    pattern = '%s/route_key-*' % RUNTIME_PATH
+    for proxy_route in glob.glob(pattern):
+        nroutes += 1
+        with open(proxy_route, 'r') as f:
+            config.extend(x.rstrip() for x in f.readlines())
+
+    config.append('}')
+
+    logger.debug('refresh_nginx_config(): added %d routes' % nroutes)
+
+    # path = '/etc/nginx/sites-enabled/proxy'
+    # path = '/tmp/proxy.conf'
+    path = '%s/proxy.conf' % RUNTIME_PATH
+
+    with open(path, 'w') as f:
+        f.write('\n'.join(config))

--- a/pouta_blueprints/views/activations.py
+++ b/pouta_blueprints/views/activations.py
@@ -67,4 +67,4 @@ class ActivationList(restful.Resource):
         db.session.add(token)
         db.session.commit()
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            send_mails.apply_async(args=[[(user.email, token.token)]], queue='system_tasks')
+            send_mails.delay([(user.email, token.token)])

--- a/pouta_blueprints/views/commons.py
+++ b/pouta_blueprints/views/commons.py
@@ -27,7 +27,6 @@ blueprint_fields = {
     'form': fields.Raw
 }
 
-
 auth = HTTPBasicAuth()
 auth.authenticate_header = lambda: "Authentication Required"
 
@@ -79,7 +78,7 @@ def invite_user(email, password=None, is_admin=False):
     db.session.commit()
 
     if not app.dynamic_config['SKIP_TASK_QUEUE'] and not app.dynamic_config['MAIL_SUPPRESS_SEND']:
-        send_mails.apply_async(args=[[(user.email, token.token)]], queue='system_tasks')
+        send_mails.delay([(user.email, token.token)])
     else:
         logging.warn(
             "email sending suppressed in config: SKIP_TASK_QUEUE:%s MAIL_SUPPRESS_SEND:%s" %

--- a/pouta_blueprints/views/instances.py
+++ b/pouta_blueprints/views/instances.py
@@ -134,10 +134,7 @@ class InstanceList(restful.Resource):
         db.session.commit()
 
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            run_update.apply_async(
-                args=[token.token, instance.id],
-                queue=get_provisioning_queue(instance.id)
-            )
+            run_update.delay(token.token, instance.id)
 
         return marshal(instance, instance_fields), 200
 
@@ -197,10 +194,7 @@ class InstanceView(restful.Resource):
         db.session.add(token)
         db.session.commit()
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            run_update.apply_async(
-                args=[token.token, instance.id],
-                queue=get_provisioning_queue(instance.id)
-            )
+            run_update.delay(token.token, instance.id)
 
     @auth.login_required
     def put(self, instance_id):
@@ -219,10 +213,7 @@ class InstanceView(restful.Resource):
                 and blueprint.config['allow_update_client_connectivity']:
             instance.client_ip = form.client_ip.data
             if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-                update_user_connectivity.apply_async(
-                    args=[instance.id],
-                    queue=get_provisioning_queue(instance.id)
-                )
+                update_user_connectivity.delay(instance.id)
             db.session.commit()
 
         else:

--- a/pouta_blueprints/views/instances.py
+++ b/pouta_blueprints/views/instances.py
@@ -12,7 +12,7 @@ from pouta_blueprints.models import db, Blueprint, Instance, User, SystemToken
 from pouta_blueprints.forms import InstanceForm, UserIPForm
 from pouta_blueprints.server import app, restful
 from pouta_blueprints.utils import requires_admin, memoize
-from pouta_blueprints.tasks import run_update, update_user_connectivity, get_provisioning_queue
+from pouta_blueprints.tasks import run_update, update_user_connectivity
 from pouta_blueprints.views.commons import auth
 
 instances = FlaskBlueprint('instances', __name__)
@@ -134,7 +134,7 @@ class InstanceList(restful.Resource):
         db.session.commit()
 
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            run_update.delay(token.token, instance.id)
+            run_update.delay(instance.id)
 
         return marshal(instance, instance_fields), 200
 
@@ -194,7 +194,7 @@ class InstanceView(restful.Resource):
         db.session.add(token)
         db.session.commit()
         if not app.dynamic_config.get('SKIP_TASK_QUEUE'):
-            run_update.delay(token.token, instance.id)
+            run_update.delay(instance.id)
 
     @auth.login_required
     def put(self, instance_id):


### PR DESCRIPTION
- Add central routing, remove explicit queues from celery tasks
  - apply_async() calls changed to delay() - no queue arg needed
- Split tasks.py into a package + modules
  - main celery app lives in celery_app.py
  - task declarations exported in **init**.py
  - task implementations are split into modules by category
  - all tasks on instances now only have instance_id as argument
