### PR TITLE
delay showing the access link to user

### DIFF
--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -183,6 +183,8 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
                 return Instance.STATE_QUEUEING
         finally:
             pbclient.release_lock(lock_id)
+            # give proxy and container some time to initialize
+            time.sleep(2)
 
     def _do_provision(self, token, instance_id, cur_ts):
         ap = self._get_ap()

--- a/pouta_blueprints/static/partials/user_dashboard.html
+++ b/pouta_blueprints/static/partials/user_dashboard.html
@@ -34,11 +34,11 @@
                                 <td><small><a href="#/instance_details/{{ instance.id }}"> {{instance.name}}</a></small></td>
                                 <td><small><lifetime seconds="{{instance.lifetime_left}}"/></small></td>
                                 <td><small>
-                                    <a ng-show="instance.instance_data['endpoints'][0]['name']=='http'"
+                                    <a ng-show="instance.instance_data['endpoints'][0]['name']=='http' && instance.state=='running'"
                                        href="{{instance.instance_data['endpoints'][0].access}}" target="_blank">
                                         Open in browser
                                     </a>
-                                    <div ng-show="instance.instance_data['endpoints'][0]['name']=='SSH'">
+                                    <div ng-show="instance.instance_data['endpoints'][0]['name']=='SSH' && instance.state=='running'">
                                         {{ instance.instance_data['endpoints'][0].access }}
                                     </div>
                                 </small></td>


### PR DESCRIPTION
- only show the links when instance is in 'running' -state
- wait 2 seconds in docker driver after provisioning before entering running state
  to give proxy and server process in spawned container time to come up
