### PR TITLE
volume type and device name config support for DockerDriver

### DIFF
--- a/pouta_blueprints/config.py
+++ b/pouta_blueprints/config.py
@@ -86,6 +86,8 @@ class BaseConfig(object):
     DD_HOST_EXTRA_SGS = ''
     DD_HOST_ROOT_VOLUME_SIZE = 0
     DD_HOST_DATA_VOLUME_FACTOR = 4
+    DD_HOST_DATA_VOLUME_DEVICE = '/dev/vdc'
+    DD_HOST_DATA_VOLUME_TYPE = ''
 
     EXTERNAL_HTTPS_PORT = 443
 

--- a/pouta_blueprints/services/openstack_service.py
+++ b/pouta_blueprints/services/openstack_service.py
@@ -163,7 +163,7 @@ class CreateRootVolume(task.Task):
 
 
 class CreateDataVolume(task.Task):
-    def execute(self, display_name, data_volume_size, config):
+    def execute(self, display_name, data_volume_size, data_volume_type, config):
         if data_volume_size:
             logging.debug("creating a data volume for instance %s, %d" % (display_name, data_volume_size))
             nc = get_openstack_nova_client(config)
@@ -171,7 +171,8 @@ class CreateDataVolume(task.Task):
 
             volume = nc.volumes.create(
                 size=data_volume_size,
-                display_name=volume_name
+                display_name=volume_name,
+                volume_type=data_volume_type,
             )
             self.volume_id = volume.id
             retries = 0
@@ -471,7 +472,7 @@ class OpenStackService(object):
 
     def provision_instance(self, display_name, image_name, flavor_name, public_key, extra_sec_groups=None,
                            master_sg_name=None, allocate_public_ip=True, root_volume_size=0,
-                           data_volume_size=0, userdata=None):
+                           data_volume_size=0, data_volume_type=None, userdata=None):
         try:
             flow, _ = get_provision_flow()
             return taskflow.engines.run(flow, engine='parallel', store=dict(
@@ -484,6 +485,7 @@ class OpenStackService(object):
                 allocate_public_ip=allocate_public_ip,
                 root_volume_size=root_volume_size,
                 data_volume_size=data_volume_size,
+                data_volume_type=data_volume_type,
                 userdata=userdata,
                 config=self._config))
         except Exception as e:

--- a/pouta_blueprints/tests/test_docker_driver.py
+++ b/pouta_blueprints/tests/test_docker_driver.py
@@ -52,7 +52,8 @@ class OpenStackServiceMock(object):
     def provision_instance(self, display_name, image_name, flavor_name,
                            public_key, extra_sec_groups=None,
                            master_sg_name=None, allocate_public_ip=True,
-                           root_volume_size=0, data_volume_size=0, userdata=None
+                           root_volume_size=0, data_volume_size=0, data_volume_type=None,
+                           userdata=None
                            ):
         self.spawn_count += 1
         res = dict(
@@ -203,7 +204,7 @@ class DockerDriverAccessMock(object):
     def get_pb_client(self, token, base_url, ssl_verify):
         return self.pbc_mock
 
-    def run_ansible_on_host(self, host, custom_logger):
+    def run_ansible_on_host(self, host, custom_logger, config):
         if self.failure_mode:
             raise RuntimeError
 
@@ -254,6 +255,8 @@ class DockerDriverTestCase(BaseTestCase):
             DD_HOST_EXTRA_SGS='',
             DD_HOST_ROOT_VOLUME_SIZE=0,
             DD_HOST_DATA_VOLUME_FACTOR=4,
+            DD_HOST_DATA_VOLUME_DEVICE='/dev/vdc',
+            DD_HOST_DATA_VOLUME_TYPE='',
         )
         dd = docker_driver.DockerDriver(logger, config)
         dd._ap = DockerDriverAccessMock(config)


### PR DESCRIPTION
- added 2 new variables to DockerDriver
  - DD_HOST_DATA_VOLUME_DEVICE - device name for docker backing storage
  - DD_HOST_DATA_VOLUME_TYPE - OpenStack volume type (flavor) for data volume
- added data_volume_type parameter for OpenStackService CreateDataVolume task
- added new variables to unit tests
