### PR TITLE
expose the housekeeping lock with info level logging

### DIFF
--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -412,7 +412,7 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
         try:
             return self._do_housekeep_locked(token)
         except LockTimeout:
-            self.logger.debug('do_housekeep(): another thread is locking, skipping')
+            self.logger.info('do_housekeep(): another thread is locking, skipping')
 
     @locked('%s/docker_driver_housekeep' % DD_RUNTIME_PATH, 1)
     def _do_housekeep_locked(self, token):


### PR DESCRIPTION
bump the verbosity level for docker driver housekeeping up to info in case there is another process active - or there is a stale lock.
