### PR TITLE
compare slots to small flavor

### DIFF
--- a/ansible/roles/docker_host/tasks/main.yml
+++ b/ansible/roles/docker_host/tasks/main.yml
@@ -1,5 +1,4 @@
-- name: Disable auto-updates on Pouta
-  file: name=/etc/cron.daily/automatic_updates state=absent
+
 
 - name: Add docker repo key (Ubuntu)
   apt_key: keyserver=keyserver.ubuntu.com id=36A1D7869245C8950F966E92D8576A8BA88D21E9

--- a/pouta_blueprints/drivers/provisioning/docker_driver.py
+++ b/pouta_blueprints/drivers/provisioning/docker_driver.py
@@ -541,8 +541,8 @@ class DockerDriver(base_driver.ProvisioningDriverBase):
             # if the host has been used or it is a bigger flavor, calculate lifetime normally
             elif host.get('lifetime_tick_ts', 0):
                 lifetime = max(DD_HOST_LIFETIME - (cur_ts - host['lifetime_tick_ts']), 0)
-            # if the host is the only one and bigger flavor, don't leave it waiting
-            elif len(hosts) == 1 and host['num_slots'] == self.config['DD_HOST_FLAVOR_SLOTS_LARGE']:
+            # if the host is the only one and not smaller flavor, don't leave it waiting
+            elif len(hosts) == 1 and host['num_slots'] != self.config['DD_HOST_FLAVOR_SLOTS_SMALL']:
                 host['lifetime_tick_ts'] = cur_ts
                 lifetime = DD_HOST_LIFETIME
             # host has not been used


### PR DESCRIPTION
- in case the flavors are identical, we now detect the standby situation properly
- better unit tests: heterogeneous host config
- fixes #471 
