### PR TITLE
Add X-Frame-Options DENY to web-ui nginx. Closes #485

### DIFF
--- a/ansible/roles/frontend/templates/etc/nginx/conf.d/pouta-blueprints.conf.j2
+++ b/ansible/roles/frontend/templates/etc/nginx/conf.d/pouta-blueprints.conf.j2
@@ -33,6 +33,8 @@ server {
     client_body_timeout 10s;
     client_header_timeout 10s;
 
+    add_header X-Frame-Options DENY;
+
     location /api {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
When in doubt, deny everything.

We could also have that only for the front-end pages and exclude /api. I don't see any harm in /api also returning the header at the moment, though.
