### PR TITLE
an empty href triggers a page load in Chrome

### DIFF
--- a/pouta_blueprints/static/partials/welcome.html
+++ b/pouta_blueprints/static/partials/welcome.html
@@ -15,10 +15,8 @@
         </div>
     </div>
     <div class="row" ><div class="col-md-6 col-xs-6" ng-show="!getLoginVisibility()">
-        <p><a href="" ng-click="toggleLoginVisibility()"
+        <p><a href="javascript:;" ng-click="toggleLoginVisibility()"
         name="click-show-login">Click here for alternate login</a></p>
-        <!-- <button class="btn btn-xs btn-default" ng-click="toggleLoginVisibility()"
-        name="click-show-login">Alternate login</button>-->
         </div>
     </div>
     <div class="row" ng-show="getLoginVisibility()" name="password-login">


### PR DESCRIPTION
Strangely enough href="#" also triggered something odd but at least href="javascript:;" did the trick. I wonder if we could just omit href.
