### PR TITLE
Make migrations work better with SQLite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ or
 After the installation the first admin user is created by using the
 initialization form at (https://localhost:8888/#/initialize). The development 
 environment uses a self-signed certificate.
+
+
+## Database migrations ##
+
+Check out [database_migrations.md](doc/database_migrations.md) for how to run
+or create migrations.

--- a/doc/database_migrations.md
+++ b/doc/database_migrations.md
@@ -1,0 +1,68 @@
+# Database Migrations #
+
+The tool stack we use for databases is SQLAlchemy, Alembic, Flask-SQLAlchemy
+and Flask-Migrate.
+
+## Overview ##
+
+It's always possible to just use the db.create_all() to create all database
+tables based on code at that point. This is what unit tests do to save time.
+Because production databases have a state in the form of the data in them we
+have to have migrations.
+
+Database migration-related code is in migrations/. Migrations/env.py contains
+some general settings, e.g. naming conventions for constraints and the use of
+so-called batch mode with SQLite (that doesn't support ALTER statements). 
+
+Individual migrations are in migrations/versions. They are linked by reference
+to the previous version inside the file and must always form a single chain.
+
+## Process ##
+
+After you change the models (add fields, constraints etc), first make sure you
+have the correct packages installed etc. (ToDo: document!).
+
+Then to make sure db is up to date with latest version file, run
+
+        (env) pouta-blueprints/ $ python manage.py db upgrade
+
+This reads through all the files, introspects the state of your configured db
+(and creates it if it doesn't exist).
+
+Then to create a new file, run 
+        
+        (env) pouta-blueprints/ $ python manage.py db migrate
+
+inspect that you have a new .py file under migrations/versions and at the very
+least change the name. Sometimes something doesn't work or the system isn't
+good at divining what you want to happen so checking the actual migration code
+is very much recommended.
+
+To apply the migration you have created, run
+
+        (env) pouta-blueprints/ $ python manage.py db upgrade
+
+And the system picks up the new migration, sees that it hasn't been run yet
+and applies it.
+
+To downgrade e.g. after something appears broken and you don't want to start
+generating the db from scratch you can run
+
+        (env) pouta-blueprints/ $ python manage.py db downgrade [revision
+        identifier]
+
+## Notes ##
+
+If you use the default settings the SQLite database location will be
+at /tmp/change_me.db. Unit tests use an in-memory SQLite and live tests use a
+/tmp/change_me.livetest.db . 
+
+SQLite does not support ALTER at all, which is why we have enabled [batch
+mode](http://alembic.zzzcomputing.com/en/latest/batch.html) . The system
+promises not to do anything differently on databases that do support ALTER but
+YMMV.
+
+SQLite also permits completely unnamed constraints. This is all nice and well
+until it's necessary to modify such a constraint, which is difficult because it
+can't be referenced unambiguously.  For this reason a custom naming scheme has
+been enabled in models.py.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -41,7 +41,9 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(url=url,
+                      render_as_batch=config.get_main_option('sqlalchemy.url').startswith('sqlite:///')
+                      )
 
     with context.begin_transaction():
         context.run_migrations()
@@ -73,6 +75,7 @@ def run_migrations_online():
     context.configure(connection=connection,
                       target_metadata=target_metadata,
                       process_revision_directives=process_revision_directives,
+                        render_as_batch=config.get_main_option('sqlalchemy.url').startswith('sqlite:///'),
                       **current_app.extensions['migrate'].configure_args)
 
     try:

--- a/migrations/versions/c0732331a3c8_.py
+++ b/migrations/versions/c0732331a3c8_.py
@@ -1,14 +1,18 @@
-""" Initial migrate. Might have to ghost this in production system or export
-and import data.
+"""Initial commit.
 
-Revision ID: e47a91921333
+May be necessary to ghost this in production or do a manual migrate.
+
+SQLite seems to be stupid and require an explicit name for each constraint
+and it just won't take an empty name like all real databases.
+
+Revision ID: c0732331a3c8
 Revises: None
-Create Date: 2016-08-16 11:40:55.579305
+Create Date: 2016-09-28 15:34:30.135146
 
 """
 
 # revision identifiers, used by Alembic.
-revision = 'e47a91921333'
+revision = 'c0732331a3c8'
 down_revision = None
 
 from alembic import op
@@ -20,15 +24,15 @@ def upgrade():
     op.create_table('locks',
     sa.Column('lock_id', sa.String(length=64), nullable=False),
     sa.Column('acquired_at', sa.DateTime(), nullable=True),
-    sa.PrimaryKeyConstraint('lock_id'),
-    sa.UniqueConstraint('lock_id')
+    sa.PrimaryKeyConstraint('lock_id', name=op.f('pk_locks')),
+    sa.UniqueConstraint('lock_id', name=op.f('uq_locks_lock_id'))
     )
     op.create_table('notifications',
     sa.Column('id', sa.String(length=32), nullable=False),
     sa.Column('broadcasted', sa.DateTime(), nullable=True),
     sa.Column('subject', sa.String(length=255), nullable=True),
     sa.Column('message', sa.Text(), nullable=True),
-    sa.PrimaryKeyConstraint('id')
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_notifications'))
     )
     op.create_table('plugins',
     sa.Column('id', sa.String(length=32), nullable=False),
@@ -36,7 +40,7 @@ def upgrade():
     sa.Column('schema', sa.Text(), nullable=True),
     sa.Column('form', sa.Text(), nullable=True),
     sa.Column('model', sa.Text(), nullable=True),
-    sa.PrimaryKeyConstraint('id')
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_plugins'))
     )
     op.create_table('users',
     sa.Column('id', sa.String(length=32), nullable=False),
@@ -48,8 +52,8 @@ def upgrade():
     sa.Column('is_blocked', sa.Boolean(), nullable=True),
     sa.Column('credits_quota', sa.Float(), nullable=True),
     sa.Column('latest_seen_notification_ts', sa.DateTime(), nullable=True),
-    sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('email')
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_users')),
+    sa.UniqueConstraint('email', name=op.f('uq_users_email'))
     )
     op.create_table('variables',
     sa.Column('id', sa.String(length=32), nullable=False),
@@ -57,14 +61,14 @@ def upgrade():
     sa.Column('value', sa.String(length=512), nullable=True),
     sa.Column('readonly', sa.Boolean(), nullable=True),
     sa.Column('t', sa.String(length=16), nullable=True),
-    sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('key')
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_variables')),
+    sa.UniqueConstraint('key', name=op.f('uq_variables_key'))
     )
     op.create_table('activation_tokens',
     sa.Column('token', sa.String(length=32), nullable=False),
     sa.Column('user_id', sa.String(length=32), nullable=True),
-    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
-    sa.PrimaryKeyConstraint('token')
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], name=op.f('fk_activation_tokens_user_id_users')),
+    sa.PrimaryKeyConstraint('token', name=op.f('pk_activation_tokens'))
     )
     op.create_table('blueprints',
     sa.Column('id', sa.String(length=32), nullable=False),
@@ -75,15 +79,15 @@ def upgrade():
     sa.Column('maximum_lifetime', sa.Integer(), nullable=True),
     sa.Column('preallocated_credits', sa.Boolean(), nullable=True),
     sa.Column('cost_multiplier', sa.Float(), nullable=True),
-    sa.ForeignKeyConstraint(['plugin'], ['plugins.id'], ),
-    sa.PrimaryKeyConstraint('id')
+    sa.ForeignKeyConstraint(['plugin'], ['plugins.id'], name=op.f('fk_blueprints_plugin_plugins')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_blueprints'))
     )
     op.create_table('keypairs',
     sa.Column('id', sa.String(length=32), nullable=False),
     sa.Column('user_id', sa.String(length=32), nullable=True),
     sa.Column('_public_key', sa.String(length=450), nullable=True),
-    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
-    sa.PrimaryKeyConstraint('id')
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], name=op.f('fk_keypairs_user_id_users')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_keypairs'))
     )
     op.create_table('instances',
     sa.Column('id', sa.String(length=32), nullable=False),
@@ -99,10 +103,10 @@ def upgrade():
     sa.Column('to_be_deleted', sa.Boolean(), nullable=True),
     sa.Column('error_msg', sa.String(length=256), nullable=True),
     sa.Column('instance_data', sa.Text(), nullable=True),
-    sa.ForeignKeyConstraint(['blueprint_id'], ['blueprints.id'], ),
-    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
-    sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('name')
+    sa.ForeignKeyConstraint(['blueprint_id'], ['blueprints.id'], name=op.f('fk_instances_blueprint_id_blueprints')),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], name=op.f('fk_instances_user_id_users')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_instances')),
+    sa.UniqueConstraint('name', name=op.f('uq_instances_name'))
     )
     ### end Alembic commands ###
 

--- a/pouta_blueprints/models.py
+++ b/pouta_blueprints/models.py
@@ -5,6 +5,7 @@ from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy import func
 from sqlalchemy.ext.hybrid import hybrid_property, Comparator
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.schema import MetaData
 from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
 import logging
 import uuid
@@ -23,6 +24,15 @@ MAX_VARIABLE_VALUE_LENGTH = 512
 MAX_NOTIFICATION_SUBJECT_LENGTH = 255
 
 db = SQLAlchemy()
+
+convention = {
+    "ix": 'ix_%(column_0_label)s',
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s"
+}
+
+db.Model.metadata = MetaData(naming_convention=convention)
 
 bcrypt = Bcrypt()
 


### PR DESCRIPTION
Add batch mode support for migration when running against SQLite.

Explicitly name each constraint using naming_convention so that
they can be later referenced unambiguously.

This is backwards incompatible because the naming used to be implicit and I haven't checked that the implicit and explicit names match across backends.
