### PR TITLE
A simple implementation of confirming destroy.

### DIFF
--- a/pouta_blueprints/static/partials/user_dashboard.html
+++ b/pouta_blueprints/static/partials/user_dashboard.html
@@ -44,9 +44,21 @@
                                         </div>
                                     </small></td>
                                     <td>
-                                        <button ng-click="deprovision(instance)" type="submit" class="btn btn-xs btn-danger" ng-disabled="instance.state=='deleting'" >
+                                        <button ng-click="showDelete = true;"
+                                            class="btn btn-default">
                                             <span class="glyphicon glyphicon-remove"></span> Destroy
                                         </button>
+                                        <p ng-show="showDelete">
+                                        I understand that destroying the
+                                                  instance deletes unsaved
+                                                  data: <input type="checkbox"
+                                        ng-model="deleteChecked" aria-label="Toggle
+                                        nghide"><br/>
+
+                                        <button ng-show="deleteChecked"
+                                                ng-click="deprovision(instance)"
+                                                  type="button", class="btn
+                                                  btn-danger">Destroy</button>
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
Has a known issue with angular refreshing the list and disappearing the
dialog.

@apurva3000 have a look and tell me if you think we need to handle this more elegantly by stopping the refresh cycle if a user starts to destroy an instance. Halting the refresh has issues of it's own and knowing when to continue refreshing is nontrivial.
