### PR TITLE
Change to Ansible 2.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(2) do |config|
       "all_groups:children" => ["api", "worker", "frontend"]
     }
     ansible.verbose='vv'
-    ansible.install=false
+    ansible.install=true
     ansible.provisioning_path="/shared_folder"
   end
 

--- a/ansible/notebook_playbook.yml
+++ b/ansible/notebook_playbook.yml
@@ -1,5 +1,5 @@
 ---
 - hosts: all
-  sudo: True
+  become: True
   roles:
       - notebook_host

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,13 +1,13 @@
 ---
 - hosts:
     - docker_host
-  sudo: True
+  become: True
   roles:
     - docker_host
 
 - hosts:
     - docker_host
-  sudo: True
+  become: True
   roles:
     - single_server_with_docker
   vars:
@@ -17,28 +17,28 @@
     - api
     - worker
     - frontend
-  sudo: True
+  become: True
   roles:
       - cloud_user_with_sudo
       - common
 
 - hosts: frontend
-  sudo: True
+  become: True
   roles:
       - frontend
 
 - hosts: api
-  sudo: True
+  become: True
   roles:
       - api
 
 - hosts: worker
-  sudo: True
+  become: True
   roles:
       - worker
 
 - hosts: sso
-  sudo: True
+  become: True
   roles:
       - sso
       - cloud_user_with_sudo

--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -31,13 +31,15 @@
   when: deploy_mode == "docker"
 
 - name: ensure database is created (devel)
-  sudo_user: postgres
+  become: True
+  become_user: postgres
   postgresql_db:
     name: "{{ application_database_name }}"
   when: deploy_mode == "devel"
 
 - name: ensure user has access to database (devel)
-  sudo_user: postgres
+  become: True
+  become_user: postgres
   postgresql_user:
     db: "{{ application_database_name }}"
     name: "{{ application_database_user }}"

--- a/ansible/roles/docker_host/tasks/main.yml
+++ b/ansible/roles/docker_host/tasks/main.yml
@@ -65,11 +65,13 @@
 - name: Enable Docker service
   service: name=docker state=started enabled=yes
 
-- name: Install docker-py from pip (required by ansible, not available for Trusty as apt package, fixed version due to recent backward incompatible upgrade)
-  pip: name=docker-py version=1.1.0
+- name: >
+        Install docker-py from pip (required by ansible,
+        versioning is iffy. Also 2.0 is called docker in PyPI)
+  pip: name=docker-py version=1.7.1.
 
 - name: Install ansible from pip
-  pip: name=ansible version=1.9.0.1
+  pip: name=ansible version=2.2.1.0
 
 - name: Add cloud-user to docker group and create ssh key
   user:

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get install -y git python python-pip python-dev python-virtualenv superv
                        libffi-dev libssl-dev python-yaml libffi-dev libssl-dev lsb-release
 
 # fixed ansible version for consistency
-RUN pip install "ansible==1.9.4"
+RUN pip install "ansible==2.2.1"
 
 # tools for admistration
 RUN apt-get install -y tmux tree dstat lsof bash-completion time vim nano

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ coverage==3.7.1
 taskflow==1.18.0
 docker-py==1.4.0
 websocket_client==0.32.0
-ansible==1.9.2
+ansible==2.2.1
 lockfile==0.10.2
 python-novaclient==2.26.0
 python-cinderclient==1.3.1

--- a/scripts/install_pb.bash
+++ b/scripts/install_pb.bash
@@ -63,7 +63,7 @@ install_packages()
     fi
 
     sudo -H easy_install pip
-    sudo -H pip install ansible==1.9.0.1
+    sudo -H pip install ansible==2.2.1
 }
 
 create_creds_file()


### PR DESCRIPTION
Note that this was prompted by a security flaw in 2.1 and 2.2, so we
will be wanting to update this to 2.2.1 as soon as it's out.

Docker-py had to also be updated to 1.7.1. as anything below 1.7 wasn't
supported. ToDo: investigate moving to version 2.x, which is called just
docker in PyPI unless i'm entirely mistaken.

Also took the chance to update sudo->become .