### PR TITLE
Add email-to only to group owners.

### DIFF
--- a/pebbles/static/partials/configure.html
+++ b/pebbles/static/partials/configure.html
@@ -75,7 +75,7 @@
                 <td>{{ notification.subject }}</td>
                 <td>{{ notification.broadcasted | utcToLocale:"medium"}}</td>
                 <td>{{ notification.message }}</td>
-		<td> <button ng-confirm-click="Do you want to email this notification to all the active users?" ng-click="emailNotification(notification)" class="btn btn-default">Email Active Users</button> </td>
+		<td> <button ng-confirm-click="Do you want to email this notification to all active admins and group owners?" ng-click="emailNotification(notification)" class="btn btn-default">Email Admins and group owners</button> </td>
                 <td>
                     <button ng-click="openEditNotification(notification)" class="btn btn-primary btn-xs" type="button">
                         <span class="glyphicon glyphicon-edit"></span>

--- a/pebbles/views/notifications.py
+++ b/pebbles/views/notifications.py
@@ -1,5 +1,6 @@
 from flask.ext.restful import fields, marshal_with, reqparse
 from flask import abort, g, Blueprint
+from sqlalchemy import or_
 
 import logging
 
@@ -89,7 +90,8 @@ class NotificationView(restful.Resource):
         if not notification:
             abort(404)
         if current_user.is_admin is True and args.get('send_mail'):
-            Users = User.query.filter_by(is_active='t')
+            # Users = User.query.filter_by(is_active='t')
+            Users = User.query.filter(User.is_active == 't').filter(or_(User.is_group_owner == 't', User.is_admin == 't'))
             for user in Users:
                 if user.email != 'worker@pebbles':
                     text['subject'] = notification.subject


### PR DESCRIPTION
This is intermediate fix for sending maintenance email for admins and group_owners. 
@apurva3000  Tagging you here for verification. 