### PR TITLE
change flask extension imports

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,5 @@
 from flask import url_for
-from flask.ext.script import Manager, Server, Shell
+from flask_script import Manager, Server, Shell
 from flask_migrate import MigrateCommand, Migrate
 from werkzeug.contrib.profiler import ProfilerMiddleware
 import getpass

--- a/pebbles/forms.py
+++ b/pebbles/forms.py
@@ -4,7 +4,7 @@ cause gray hair.
 
 """
 
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms_alchemy import model_form_factory
 from wtforms import BooleanField, FloatField, StringField
 # from wtforms import FormField, FieldList

--- a/pebbles/models.py
+++ b/pebbles/models.py
@@ -1,8 +1,8 @@
 import string
 import random
-from flask.ext.bcrypt import Bcrypt
+from flask_bcrypt import Bcrypt
 import names
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import func
 from sqlalchemy.ext.hybrid import hybrid_property, Comparator
 from sqlalchemy.schema import MetaData

--- a/pebbles/server.py
+++ b/pebbles/server.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 
 from flask import render_template
-from flask.ext import restful
+import flask_restful as restful
 try:
     from flask_sso import SSO
 except:

--- a/pebbles/tests/base.py
+++ b/pebbles/tests/base.py
@@ -1,8 +1,7 @@
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 from flask_testing import LiveServerTestCase
 
 import logging
-
 
 from selenium import webdriver
 

--- a/pebbles/views/activations.py
+++ b/pebbles/views/activations.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal_with
+from flask_restful import marshal_with
 from flask import abort, Blueprint
 
 import logging

--- a/pebbles/views/blueprint_templates.py
+++ b/pebbles/views/blueprint_templates.py
@@ -1,7 +1,7 @@
-from flask.ext.restful import marshal_with, reqparse
+from flask_restful import marshal_with, reqparse
 from flask import abort, g
 from flask import Blueprint as FlaskBlueprint
-from flask.ext.restful import fields
+from flask_restful import fields
 from sqlalchemy.orm.session import make_transient
 
 import logging

--- a/pebbles/views/blueprints.py
+++ b/pebbles/views/blueprints.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal_with, fields, reqparse
+from flask_restful import marshal_with, fields, reqparse
 from flask import abort, g
 from flask import Blueprint as FlaskBlueprint
 from sqlalchemy.orm.session import make_transient

--- a/pebbles/views/commons.py
+++ b/pebbles/views/commons.py
@@ -1,5 +1,5 @@
-from flask.ext.restful import fields
-from flask.ext.httpauth import HTTPBasicAuth
+from flask_restful import fields
+from flask_httpauth import HTTPBasicAuth
 from flask import g, render_template, abort
 import logging
 from pebbles.models import db, ActivationToken, User, Group, GroupUserAssociation

--- a/pebbles/views/export_stats.py
+++ b/pebbles/views/export_stats.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import reqparse
+from flask_restful import reqparse
 from flask_restful.inputs import boolean
 from flask import Blueprint as FlaskBlueprint
 from operator import itemgetter

--- a/pebbles/views/firstuser.py
+++ b/pebbles/views/firstuser.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal_with
+from flask_restful import marshal_with
 from flask import abort
 from flask import Blueprint as FlaskBlueprint
 

--- a/pebbles/views/groups.py
+++ b/pebbles/views/groups.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal_with, reqparse
+from flask_restful import marshal_with, reqparse
 from flask import abort, g
 from flask import Blueprint as FlaskBlueprint
 import logging

--- a/pebbles/views/import_export.py
+++ b/pebbles/views/import_export.py
@@ -1,5 +1,5 @@
 from flask import g
-from flask.ext.restful import fields, marshal_with
+from flask_restful import fields, marshal_with
 from flask import Blueprint as FlaskBlueprint
 import logging
 

--- a/pebbles/views/instances.py
+++ b/pebbles/views/instances.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal, marshal_with, fields, reqparse
+from flask_restful import marshal, marshal_with, fields, reqparse
 from flask import abort, g
 from flask import Blueprint as FlaskBlueprint
 

--- a/pebbles/views/locks.py
+++ b/pebbles/views/locks.py
@@ -1,6 +1,6 @@
 from flask import Blueprint as FlaskBlueprint
 from flask import abort
-from flask.ext.restful import marshal_with, fields
+from flask_restful import marshal_with, fields
 
 from pebbles.models import db, Lock
 from pebbles.views.commons import auth

--- a/pebbles/views/namespaced_keyvalues.py
+++ b/pebbles/views/namespaced_keyvalues.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import fields, marshal_with, reqparse
+from flask_restful import fields, marshal_with, reqparse
 from flask import abort, Blueprint
 
 import logging

--- a/pebbles/views/notifications.py
+++ b/pebbles/views/notifications.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import fields, marshal_with, reqparse
+from flask_restful import fields, marshal_with, reqparse
 from flask import abort, g, Blueprint
 
 import logging

--- a/pebbles/views/plugins.py
+++ b/pebbles/views/plugins.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import fields, marshal_with
+from flask_restful import fields, marshal_with
 from flask import abort, Blueprint
 
 import logging

--- a/pebbles/views/quota.py
+++ b/pebbles/views/quota.py
@@ -1,6 +1,6 @@
 from flask import abort, g
 from flask import Blueprint as FlaskBlueprint
-from flask.ext.restful import marshal_with, fields, reqparse
+from flask_restful import marshal_with, fields, reqparse
 
 from pebbles.server import restful
 from pebbles.views.commons import auth

--- a/pebbles/views/sessions.py
+++ b/pebbles/views/sessions.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import fields, marshal
+from flask_restful import fields, marshal
 from flask import Blueprint as FlaskBlueprint
 
 import logging

--- a/pebbles/views/stats.py
+++ b/pebbles/views/stats.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal_with, fields
+from flask_restful import marshal_with, fields
 from flask import Blueprint as FlaskBlueprint
 
 import logging

--- a/pebbles/views/users.py
+++ b/pebbles/views/users.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import marshal_with, fields, reqparse
+from flask_restful import marshal_with, fields, reqparse
 from flask import abort, g
 from flask import Blueprint as FlaskBlueprint
 from sqlalchemy import desc

--- a/pebbles/views/variables.py
+++ b/pebbles/views/variables.py
@@ -1,4 +1,4 @@
-from flask.ext.restful import fields, marshal_with
+from flask_restful import fields, marshal_with
 from flask import Blueprint
 
 import logging


### PR DESCRIPTION
Nowadays one should import flask extensions with flask_<extension_name>
instead of flask.ext.<extension_name>.

https://github.com/pallets/flask/issues/1135