### PR TITLE
Refactor/s2i based deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,14 @@ target/
 # coverage related artefacts
 htmlcov/
 .coverage
+
+# package installation directories
+build/
+dist/
+pebbles-4.0.0.dev1-py2.7.egg-info/
+
+# MacOS Finder cache
+.DS_Store
+
+#VSCode settings
+.vscode

--- a/deployment/building_with_s2i.md
+++ b/deployment/building_with_s2i.md
@@ -1,0 +1,67 @@
+# How to use s2i to build a Pebbles docker image
+
+## Building locally
+
+- install s2i 
+  - you can download it from https://github.com/openshift/source-to-image/releases
+  - on a Mac, you can also 'brew install source-to-image'
+- build the image from local directory with python 3.6 builder 
+
+```bash
+# run this in the repository base directory
+s2i build . --copy -e UPGRADE_PIP_TO_LATEST=1 centos/python-36-centos7 cscfi/pebbles
+```
+
+## Building in OpenShift
+
+OpenShift can be used for building and distributing the images 
+
+### Create a build with CLI
+- prerequisite: access to the cluster
+- create a new build from cli for master branch
+
+```bash
+oc new-build centos/python-36-centos7~https://github.com/CSCfi/pebbles#master --name pebbles
+```
+
+### Create a build from Web UI
+
+- click on 'Add to project'
+- go to 'Import YAML / JSON'
+- paste the following:
+
+```yaml
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: pebbles
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: pebbles:latest
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    git:
+      ref: master
+      uri: https://github.com/CSCfi/pebbles
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: python-36-centos7:latest
+    type: Source
+  triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChange: {}
+```
+
+- to enable GitHub webhooks
+  - go to the Build page
+  - select 'Actions -> Edit'
+  - click 'Show advanced Options'
+  - for further info, see https://docs.openshift.org/latest/dev_guide/builds/triggering_builds.html

--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -1,0 +1,74 @@
+version: '2.1'
+services:
+  redis:
+    image: redis
+
+  db:
+    image: centos/postgresql-95-centos7
+    environment:
+    - POSTGRESQL_USER=pebbles
+    - POSTGRESQL_PASSWORD=pebbles
+    - POSTGRESQL_DATABASE=pebbles
+
+  api:
+    image: cscfi/pebbles:latest
+    links:
+    - db
+    - redis
+    depends_on:
+    - db
+    - redis
+    ports:
+    - '8080:8080'
+    env_file: local.env
+    environment:
+    - APP_MODULE=pebbles.server:app
+    - DB_AUTOMIGRATION=1
+    - PB_SQLALCHEMY_DATABASE_URI=postgresql://pebbles:pebbles@db/pebbles
+    - APP_CONFIG=/opt/app-root/src/deployment/gunicorn-debug.cfg
+    volumes:
+    # mount the source directory for local development
+    - ..:/opt/app-root/src:ro
+
+  worker:
+    image: cscfi/pebbles:latest
+    links:
+    - redis
+    - api
+    env_file: local.env
+    environment:
+    - APP_SCRIPT=/opt/app-root/src/deployment/run_celery.bash
+    - CELERY_PROCESS_NAME=worker
+    - CELERY_QUEUE=provisioning_tasks-1
+    - CELERY_LOGLEVEL=DEBUG
+    volumes:
+    # mount the source directory for local development
+    - ..:/opt/app-root/src:ro
+
+  system-worker:
+    image: cscfi/pebbles:latest
+    links:
+    - redis
+    - api
+    env_file: local.env
+    environment:
+    - APP_SCRIPT=/opt/app-root/src/deployment/run_celery.bash
+    - CELERY_PROCESS_NAME=system_worker
+    - CELERY_QUEUE=system_tasks
+    - CELERY_LOGLEVEL=DEBUG
+    volumes:
+# mount the source directory for local development
+    - ..:/opt/app-root/src:ro
+
+  periodical-worker:
+    image: cscfi/pebbles:latest
+    links:
+    - redis
+    - api
+    env_file: local.env
+    environment:
+    - APP_SCRIPT=/opt/app-root/src/deployment/run_celery.bash
+    - CELERY_CMD=beat
+    - CELERY_PROCESS_NAME=system_worker
+    - CELERY_QUEUE=system
+    - CELERY_LOGLEVEL=DEBUG

--- a/deployment/gunicorn-debug.cfg
+++ b/deployment/gunicorn-debug.cfg
@@ -1,0 +1,3 @@
+reload=True
+workers=1
+

--- a/deployment/local.env
+++ b/deployment/local.env
@@ -1,0 +1,8 @@
+# Globally set debugging on
+PB_DEBUG=1
+
+# Shared secret
+PB_SECRET_KEY=do_not_use_me_in_production
+
+# Internal API endpoint
+PB_INTERNAL_API_BASE_URL=http://api:8080/api/v1

--- a/deployment/local_config.yaml
+++ b/deployment/local_config.yaml
@@ -1,0 +1,2 @@
+DEBUG: True
+SECRET_KEY: do_not_use_me_in_production

--- a/deployment/pebbles-template.yml
+++ b/deployment/pebbles-template.yml
@@ -1,0 +1,623 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  app: pebbles
+  template: pebbles
+message: |-
+  The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.
+
+metadata:
+  annotations:
+    description: Pebbles
+    iconClass: icon-python
+    openshift.io/display-name: Pebbles
+    openshift.io/documentation-url: https://github.com/CSCfi/pebbles
+    openshift.io/long-description: Pebbles
+    openshift.io/provider-display-name: CSC
+    tags: pebbles,python
+    template.openshift.io/bindable: "false"
+  name: pebbles
+
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${NAME}
+  stringData:
+    database-password: ${DATABASE_PASSWORD}
+    database-user: ${DATABASE_USER}
+    pb-secret-key: ${PB_SECRET_KEY}
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes and load balances the application pods
+      service.alpha.openshift.io/dependencies: '[{"name": "${DATABASE_SERVICE_NAME}",
+        "kind": "Service"}]'
+    name: ${NAME}-api
+  spec:
+    ports:
+    - name: web
+      port: 8080
+      targetPort: 8080
+    selector:
+      name: ${NAME}-api
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: ${NAME}-api
+  spec:
+    host: ${APPLICATION_DOMAIN}
+    to:
+      kind: Service
+      name: ${NAME}-api
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the application image
+    name: ${NAME}
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: ${NAME}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${NAME}:latest
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      type: Git
+      contextDir: ${CONTEXT_DIR}
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: python:2.7
+          namespace: ${BUILD_IMAGE_NAMESPACE}
+        env:
+        - name: UPGRADE_PIP_TO_LATEST
+          value: "1"
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChange: {}
+    - type: GitHub
+      github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Pebbles API
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}-api
+  spec:
+    replicas: 1
+    selector:
+      name: ${NAME}-api
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-api
+        name: ${NAME}-api
+      spec:
+        containers:
+        - name: pebbles-api
+          env:
+          - name: APP_MODULE
+            value: pebbles.server:app
+          - name: PB_SQLALCHEMY_DATABASE_URI
+            value: postgresql://pebbles:pebbles@postgresql/pebbles
+          - name: PB_DB_AUTOMIGRATION
+            value: "1"
+          - name: PB_DEBUG
+            value: "1"
+          - name: DB_AUTOMIGRATION
+            value: "1"
+          - name: DEBUG
+            value: "1"
+          - name: GUNICORN_CMD_ARGS
+            value: "--workers=2 --max-requests=100"
+          - name: PB_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${NAME}
+                key: pb-secret-key
+          image: ' '
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            timeoutSeconds: 3
+          ports:
+          - containerPort: 8080
+          resources:
+            requests:
+              memory: ${MEMORY_API}
+            limits:
+              memory: ${MEMORY_API}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - pebbles-api
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Pebbles worker
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}-worker
+  spec:
+    replicas: 1
+    selector:
+      name: ${NAME}-worker
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-worker
+        name: ${NAME}-worker
+      spec:
+        containers:
+        - name: worker
+          env:
+          - name: APP_SCRIPT
+            value: /opt/app-root/src/deployment/run_celery.bash
+          - name: CELERY_PROCESS_NAME
+            value: worker
+          - name: CELERY_QUEUE
+            value: provisioning_tasks-1
+          - name: CELERY_LOGLEVEL
+            value: DEBUG
+          - name: PB_INTERNAL_API_BASE_URL
+            value: http://${NAME}-api:8080/api/v1
+          - name: PB_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${NAME}
+                key: pb-secret-key
+          image: ' '
+          resources:
+            requests:
+              memory: ${MEMORY_WORKER}
+            limits:
+              memory: ${MEMORY_WORKER}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - worker
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Pebbles system worker
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}-system-worker
+  spec:
+    replicas: 1
+    selector:
+      name: ${NAME}-system-worker
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-system-worker
+        name: ${NAME}-system-worker
+      spec:
+        containers:
+        - name: worker
+          env:
+          - name: APP_SCRIPT
+            value: /opt/app-root/src/deployment/run_celery.bash
+          - name: CELERY_PROCESS_NAME
+            value: system_worker
+          - name: CELERY_QUEUE
+            value: system_tasks
+          - name: CELERY_LOGLEVEL
+            value: DEBUG
+          - name: PB_INTERNAL_API_BASE_URL
+            value: http://${NAME}-api:8080/api/v1
+          - name: PB_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${NAME}
+                key: pb-secret-key
+          image: ' '
+          resources:
+            requests:
+              memory: ${MEMORY_WORKER}
+            limits:
+              memory: ${MEMORY_WORKER}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - worker
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Pebbles periodical worker
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}-periodical-worker
+  spec:
+    replicas: 1
+    selector:
+      name: ${NAME}-periodical-worker
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${NAME}-periodical-worker
+        name: ${NAME}-periodical-worker
+      spec:
+        containers:
+        - name: worker
+          env:
+          - name: APP_SCRIPT
+            value: /opt/app-root/src/deployment/run_celery.bash
+          - name: CELERY_CMD
+            value: beat
+          - name: CELERY_PROCESS_NAME
+            value: system_worker
+          - name: CELERY_QUEUE
+            value: system
+          - name: CELERY_LOGLEVEL
+            value: DEBUG
+          - name: PB_INTERNAL_API_BASE_URL
+            value: http://${NAME}-api:8080/api/v1
+          - name: PB_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${NAME}
+                key: pb-secret-key
+          image: ' '
+          resources:
+            requests:
+              memory: ${MEMORY_WORKER}
+            limits:
+              memory: ${MEMORY_WORKER}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - worker
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    storageClassName: 'standard-rwo'
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Exposes the database server
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Defines how to deploy the database
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${DATABASE_SERVICE_NAME}
+        name: ${DATABASE_SERVICE_NAME}
+      spec:
+        containers:
+        - name: postgresql
+          env:
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: ${NAME}
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: ${NAME}
+          - name: POSTGRESQL_DATABASE
+            value: ${DATABASE_NAME}
+          image: ' '
+          livenessProbe:
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 5432
+            timeoutSeconds: 1
+          ports:
+          - containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - psql -h 127.0.0.1 -U ${POSTGRESQL_USER} -q -d ${POSTGRESQL_DATABASE}
+                -c 'SELECT 1'
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            requests:
+              memory: ${MEMORY_POSTGRESQL}
+            limits:
+              memory: ${MEMORY_POSTGRESQL}
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: ${DATABASE_SERVICE_NAME}-data
+        volumes:
+        - name: ${DATABASE_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${DATABASE_SERVICE_NAME}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - postgresql
+        from:
+          kind: ImageStreamTag
+          name: postgresql:9.5
+          namespace: ${BUILD_IMAGE_NAMESPACE}
+      type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: redis://{.spec.clusterIP}:{.spec.ports[?(.name=="redis")].port}
+    name: redis
+  spec:
+    ports:
+    - name: redis
+      nodePort: 0
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+    selector:
+      name: redis
+    sessionAffinity: None
+    type: ClusterIP
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: redis
+  spec:
+    replicas: 1
+    selector:
+      name: redis
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: redis
+      spec:
+        containers:
+        - capabilities: {}
+          env: {}
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 6379
+            timeoutSeconds: 1
+          name: redis
+          ports:
+          - containerPort: 6379
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - test "$(redis-cli -h 127.0.0.1 ping)" == "PONG"
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            requests:
+              memory: 100Mi
+            limits:
+              memory: 100Mi
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/redis/data
+            name: redis-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - emptyDir: {}
+          name: redis-data
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - redis
+        from:
+          kind: ImageStreamTag
+          name: redis:3.2
+          namespace: openshift
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+
+parameters:
+- description: The name assigned to all of the frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: pebbles
+
+- description: The OpenShift Namespace where the build image ImageStream resides.
+  displayName: Build Image Namespace
+  name: BUILD_IMAGE_NAMESPACE
+  required: true
+  value: openshift
+
+- description: Memory for API container
+  displayName: Memory (API)
+  name: MEMORY_API
+  required: true
+  value: 200Mi
+
+- description: Memory for worker containers
+  displayName: Memory (workers)
+  name: MEMORY_WORKER
+  required: true
+  value: 200Mi
+
+- description: The URL of the repository with your application source code.
+  displayName: Git Repository URL
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/CSCfi/pebbles
+
+- description: Set this to a branch name, tag or other ref of your repository if you
+    are not using the default branch.
+  displayName: Git Reference
+  name: SOURCE_REPOSITORY_REF
+
+- description: Set this to the relative path to your project if it is not in the root
+    of your repository.
+  displayName: Context Directory
+  name: CONTEXT_DIR
+
+- description: The exposed hostname that will route to the Flask service, if left
+    blank a value will be defaulted.
+  displayName: Application Hostname
+  name: APPLICATION_DOMAIN
+
+- description: Github trigger secret.  A difficult to guess string encoded as part
+    of the webhook URL.  Not encrypted.
+  displayName: GitHub Webhook Secret
+  from: '[a-zA-Z0-9]{40}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET
+
+- displayName: Database Service Name
+  name: DATABASE_SERVICE_NAME
+  required: true
+  value: postgresql
+
+- displayName: Database Name
+  name: DATABASE_NAME
+  required: true
+  value: pebbles
+
+- displayName: Database Username
+  name: DATABASE_USER
+  required: true
+  value: pebbles
+
+- displayName: Database User Password
+  from: '[a-zA-Z0-9]{16}'
+  value: pebbles
+  name: DATABASE_PASSWORD
+
+- description: Memory for PostgreSQL container
+  displayName: Memory (PostgreSQL)
+  name: MEMORY_POSTGRESQL
+  required: true
+  value: 200Mi
+
+- description: Volume space available for data, e.g. 512Mi, 2Gi
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 2Gi
+
+- description: Relative path to Gunicorn configuration file (optional).
+  displayName: Application Configuration File Path
+  name: APP_CONFIG
+
+- description: The custom PyPi index URL
+  displayName: Custom PyPi Index URL
+  name: PIP_INDEX_URL
+
+- description: Secret master key
+  displayName: Secret master key
+  from: '[a-zA-Z0-9]{40}'
+  generate: expression
+  name: PB_SECRET_KEY

--- a/deployment/pebbles-template.yml
+++ b/deployment/pebbles-template.yml
@@ -193,6 +193,10 @@ objects:
       spec:
         containers:
         - name: worker
+          volumeMounts:
+            - name: ${NAME}-m2m-vol
+              mountPath: ${M2M_STORE}
+              readOnly: true
           env:
           - name: APP_SCRIPT
             value: /opt/app-root/src/deployment/run_celery.bash
@@ -202,6 +206,8 @@ objects:
             value: provisioning_tasks-1
           - name: CELERY_LOGLEVEL
             value: DEBUG
+          - name: PB_PLUGIN_WHITELIST
+            value: ${PLUGIN_WHITELIST}
           - name: PB_INTERNAL_API_BASE_URL
             value: http://${NAME}-api:8080/api/v1
           - name: PB_SECRET_KEY
@@ -209,12 +215,18 @@ objects:
               secretKeyRef:
                 name: ${NAME}
                 key: pb-secret-key
+          - name: PB_M2M_CREDENTIAL_STORE
+            value: ${M2M_STORE}/${NAME}-m2m
           image: ' '
           resources:
             requests:
               memory: ${MEMORY_WORKER}
             limits:
               memory: ${MEMORY_WORKER}
+        volumes:
+          - name: ${NAME}-m2m-vol
+            secret:
+              secretName: ${NAME}-m2m
     triggers:
     - imageChangeParams:
         automatic: true
@@ -256,6 +268,8 @@ objects:
             value: system_tasks
           - name: CELERY_LOGLEVEL
             value: DEBUG
+          - name: PB_PLUGIN_WHITELIST
+            value: ${PLUGIN_WHITELIST}
           - name: PB_INTERNAL_API_BASE_URL
             value: http://${NAME}-api:8080/api/v1
           - name: PB_SECRET_KEY
@@ -616,8 +630,15 @@ parameters:
   displayName: Custom PyPi Index URL
   name: PIP_INDEX_URL
 
+- displayName: Plugins whitelist
+  name: PLUGIN_WHITELIST
+  value: OpenShiftDriver
+
 - description: Secret master key
   displayName: Secret master key
-  from: '[a-zA-Z0-9]{40}'
-  generate: expression
   name: PB_SECRET_KEY
+  value: change_me
+
+- displayName: M2M Credentials Store
+  name: M2M_STORE
+  value: /run/shm

--- a/deployment/run_celery.bash
+++ b/deployment/run_celery.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+export C_FORCE_ROOT=1
+
+CELERY_CMD=${CELERY_CMD:-worker}
+CELERY_LOGLEVEL=${CELERY_LOGLEVEL:-INFO}
+
+case $CELERY_CMD in
+    worker)
+        celery worker \
+            -n $CELERY_PROCESS_NAME \
+            -Q $CELERY_QUEUE \
+            -A pebbles.tasks.celery_app $CELERY_APP_ARGS \
+            -Ofair \
+            --loglevel=$CELERY_LOGLEVEL \
+            --concurrency=8 \
+            --maxtasksperchild=50
+    ;;
+    beat)
+        celery beat \
+            -A pebbles.tasks.celery_app $CELERY_APP_ARGS
+    ;;
+esac

--- a/doc/source/admin_guide.rst
+++ b/doc/source/admin_guide.rst
@@ -14,6 +14,7 @@ Contents:
    
    system_architecture
    how_to_install_on_cpouta
+   how_to_deploy_on_openshift
    database_migrations
    configuring
    drivers

--- a/doc/source/how_to_deploy_on_openshift.rst
+++ b/doc/source/how_to_deploy_on_openshift.rst
@@ -1,0 +1,22 @@
+How to launch a Pebbles service on Rahti
+****************************************
+
+Prerequisites
+=============
+
+* Account on Rahti/Rahti-int
+* OpenShift command line tools
+* See Rahti/Rahti-int documention to get the basic bootstrapping done
+* Pebbles source tree
+
+Deployment
+==========
+
+Create a new project for your deployment::
+
+    $ oc new-project pebbles-$USER
+
+In the source directory, create the server from the template::
+
+    $ oc process SOURCE_REPOSITORY_REF=refactor/openshift -f deployment/pebbles-template.yml | oc apply -f -
+

--- a/pebbles/app.py
+++ b/pebbles/app.py
@@ -23,6 +23,18 @@ def favicon():
     return app.send_static_file('favicon.ico')
 
 
+@app.after_request
+def add_header(r):
+    r.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    r.headers["Pragma"] = "no-cache"
+    r.headers["Expires"] = "0"
+    r.headers['Strict-Transport-Security'] = 'max-age=31536000'
+    # does not work without unsafe-inline / unsafe-eval
+    r.headers['Content-Security-Policy'] = "img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' wss://{{ domain_name }} ; style-src 'self' 'unsafe-inline'; default-src 'self'"
+
+    return r
+
+
 test_run = set(['test', 'covtest']).intersection(set(sys.argv))
 
 if test_run:
@@ -45,7 +57,7 @@ bcrypt.init_app(app)
 db.init_app(app)
 
 
-def run_things_in_context(test_run):
+def run_things_in_context(is_test_run):
     # This is only split into a function so we can easily test some of it's
     # behavior.
     with app.app_context():
@@ -54,7 +66,7 @@ def run_things_in_context(test_run):
         # in the future
         if os.environ.get("DB_AUTOMIGRATION", None) and \
            os.environ.get("DB_AUTOMIGRATION", None) not in ["0", 0] and \
-           not test_run:
+           not is_test_run:
             flask_upgrade_db_to_head()
 
 

--- a/pebbles/tests/test_flask_api.py
+++ b/pebbles/tests/test_flask_api.py
@@ -2523,6 +2523,14 @@ class FlaskApiTestCase(BaseTestCase):
         )
         self.assertStatus(invalid_response, 404)
 
+    def test_headers(self):
+        """Test that we set headers for content caching and security"""
+        response = self.make_request(path='/api/v1/config')
+
+        required_headers = ('Cache-Control', 'Expires', 'Strict-Transport-Security', 'Content-Security-Policy')
+        for h in required_headers:
+            self.assertIn(h, response.headers.keys())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,3 +107,7 @@ WTForms==2.1
 WTForms-Alchemy==0.13.0
 WTForms-Components==0.9.9
 python-neutronclient==6.1.1
+
+# for s2i
+psycopg2==2.7.1
+gunicorn==19.7.1

--- a/scripts/oc_rsync_source.bash
+++ b/scripts/oc_rsync_source.bash
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#
+# This script watches for changes and synchronizes current directory contents
+# to pods matching 'name' labels given by the command line.
+#
+# The script is useful when you want to test changes quickly in a development
+# environment deployed in OpenShift.
+#
+# Requires inotifywait
+#
+
+EXCLUDE='*.pyc,.idea,.git,target,.vagrant,__pycache__'
+
+if [[ "xxx$1" == "xxx" ]]; then
+    echo
+    echo "Usage: $0 <pod_name_label_1> [<pod_name_label_2> ...]"
+    echo
+    echo "  Example: in pebbles source root directory, run"
+    echo "    scripts/oc_rsync_source.bash pebbles-api pebbles-worker"
+    echo
+    exit 1
+fi
+
+# loop with a one second backoff
+while sleep 1; do
+    # synchronize current directory with pods matching given arguments
+    for name in $*; do
+        pod_name=$(oc get pod -l name=$name | tail -1 | cut -f 1 -d ' ')
+        echo
+        echo "$(date -Is) rsyncing to $pod_name"
+        echo
+        oc rsync --exclude=$EXCLUDE . $pod_name:.
+    done
+
+    # wait for modifications in files
+    inotifywait -r -e modify .
+
+done

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,12 @@
-import setuptools
-setuptools.setup(setup_requires=['pbr'], pbr=True)
+from setuptools import setup
+
+setup(
+    entry_points={
+        'pebbles.drivers.provisioning': [
+            'DummyDriver = pebbles.drivers.provisioning.dummy_driver:DummyDriver',
+            'OpenStackDriver = pebbles.drivers.provisioning.openstack_driver:OpenStackDriver',
+            'DockerDriver = pebbles.drivers.provisioning.docker_driver:DockerDriver',
+            'OpenShiftDriver = pebbles.drivers.provisioning.openshift_driver:OpenShiftDriver',
+        ],
+    },
+)


### PR DESCRIPTION
This patch adds rudimentary support for source-to-image based
deployments for running locally with docker-compose and in an OpenShift
cluster.

Changes and additions:

- pbr setup converted to plain setuptools for s2i
- added docs for building with s2i and OpenShift
- added docker compose file for local development
- added simple OpenShift template for deploying on OpenShift
- add cache headers to all requests to enable content reloading in
  browsers in case we are not running with an nginx proxy in front
- add gunicorn debug configuration (reload, single worker)
- added macos and vscode files to .gitignore