### PR TITLE
Hide enable-user-view option for normal users. Closes #845.

### DIFF
--- a/pebbles/static/js/controllers/AccountController.js
+++ b/pebbles/static/js/controllers/AccountController.js
@@ -4,14 +4,12 @@ app.controller('AccountController', ['$q', '$scope', '$timeout', 'AuthService', 
     var quota = Restangular.one('quota', AuthService.getUserId());
     var group_join = Restangular.all('groups').one('group_join');
 
-    var isUserRoleForced = false;
     var key = null;
     var key_url = null;
     var change_password_result = "";
     var upload_ok = null;
 
     $scope.getUserName = AuthService.getUserName;
-    $scope.userRoleStatus = "Enable User View"
 
     $scope.isAdmin = function() {
         return AuthService.isAdmin();
@@ -19,19 +17,6 @@ app.controller('AccountController', ['$q', '$scope', '$timeout', 'AuthService', 
 
     $scope.isGroupManagerOrAdmin = function() {
         return AuthService.isGroupManagerOrAdmin();
-    };
-
-    $scope.toggleUserRoleForced = function() {
-        isUserRoleForced = AuthService.getUserRoleForcedStatus();
-        if (isUserRoleForced === null || isUserRoleForced === 'false'){
-           isUserRoleForced = 'true';
-           $scope.userRoleStatus = "Disable User View";
-        }
-        else{
-           isUserRoleForced = 'false';
-           $scope.userRoleStatus = "Enable User View";
-        }
-        AuthService.setUserRoleForcedStatus(isUserRoleForced);
     };
 
     quota.get().then(function (response) {

--- a/pebbles/static/js/services/AuthService.js
+++ b/pebbles/static/js/services/AuthService.js
@@ -56,10 +56,6 @@ app.factory('AuthService', ['$q', 'localStorageService', 'Session', 'Restangular
 
         isAdmin : function() {
             var adminStatus = this.getAdminStatus();
-            var isUserRoleForced = this.getUserRoleForcedStatus();
-            if (isUserRoleForced === "true"){
-                return false;
-            }
             if (adminStatus === "true") {
                 return true;
             }
@@ -69,10 +65,6 @@ app.factory('AuthService', ['$q', 'localStorageService', 'Session', 'Restangular
         isGroupOwnerOrAdmin : function() {
             var groupOwnerStatus = this.getGroupOwnerStatus();
             var adminStatus = this.getAdminStatus();
-            var isUserRoleForced = this.getUserRoleForcedStatus();
-            if (isUserRoleForced === "true"){
-                return false;
-            }
             if (groupOwnerStatus === "true" || adminStatus === "true") {
                 return true;
             }
@@ -83,10 +75,6 @@ app.factory('AuthService', ['$q', 'localStorageService', 'Session', 'Restangular
             var groupManagerStatus = this.getGroupManagerStatus();
             var groupOwnerStatus = this.getGroupOwnerStatus();
             var adminStatus = this.getAdminStatus();
-            var isUserRoleForced = this.getUserRoleForcedStatus();
-            if (isUserRoleForced === "true"){
-                return false;
-            }
             if (groupManagerStatus === "true" || groupOwnerStatus === "true" || adminStatus === "true") {
                 return true;
             }
@@ -151,13 +139,6 @@ app.factory('AuthService', ['$q', 'localStorageService', 'Session', 'Restangular
         },
 
 
-        setUserRoleForcedStatus : function(isUserRoleForced) {
-            localStorageService.set('isUserRoleForced', isUserRoleForced);
-        },
-
-        getUserRoleForcedStatus : function() {
-            return localStorageService.get('isUserRoleForced');
-        }
     };
 }]);
 

--- a/pebbles/static/partials/account.html
+++ b/pebbles/static/partials/account.html
@@ -7,11 +7,6 @@
         </div>
     </div>
 
-<div class="row">
-     <div class="col-md-6">
-    <button class="btn btn-primary" ng-click="toggleUserRoleForced()">{{ userRoleStatus }}</button>
-    </div>
-</div>
 
 <div class="row" ng-hide="isAdmin()">
    <div class="col-md-6">


### PR DESCRIPTION
This will hide button "enable/disable user view" for regular users. 

But there is still a problem that 
1. Group_owners enabling this option , they can see other group_owner features like groups etc. 
2. Should double use the button when they return to Accounts to see the disable option.  
3. And double use the button on certain cases to use this feature for first time. 

