### PR TITLE
docker driver: overlay2 and prepare host fix

### DIFF
--- a/ansible/roles/notebook_host/tasks/setup_block_storage.yml
+++ b/ansible/roles/notebook_host/tasks/setup_block_storage.yml
@@ -44,24 +44,33 @@
   command: swapon /dev/mapper/vg_ephemeral-swap
   when: swap_configured|failed
 
-- name: Check for docker thin pool
+- name: Check for docker LV
   command: lvdisplay vg_ephemeral/docker
   register: test_lv_docker
   ignore_errors: yes
 
-- name: Create docker thin pool
+- name: Create docker volume
   lvol:
     vg: vg_ephemeral
     lv: docker
     size: 100%FREE
-    opts: --poolmetadatasize 1G -T
   when: test_lv_docker|failed
 
-- name: Upload custom docker storage configuration
-  template:
-    src=etc/sysconfig/docker-storage.j2
-    dest=/etc/sysconfig/docker-storage
-    backup=True
-  notify: restart docker
-  when: ansible_lsb.id=="CentOS" and ansible_lsb.major_release=="7"
+- name: Format docker LV with xfs
+  filesystem:
+    fstype: xfs
+    dev: /dev/mapper/vg_ephemeral-docker
 
+- name: Create /var/lib/docker
+  file:
+    dest: /var/lib/docker
+    state: directory
+    owner: root
+    group: root
+
+- name: Mount /var/lib/docker
+  mount:
+    src: /dev/mapper/vg_ephemeral-docker
+    name: /var/lib/docker
+    state: mounted
+    fstype: xfs

--- a/ansible/roles/notebook_host/templates/etc/sysconfig/docker-storage.j2
+++ b/ansible/roles/notebook_host/templates/etc/sysconfig/docker-storage.j2
@@ -1,4 +1,0 @@
-DOCKER_STORAGE_OPTIONS=--storage-driver devicemapper \
-  --storage-opt dm.fs=xfs\
-  --storage-opt dm.thinpooldev=/dev/mapper/vg_ephemeral-docker\
-  --storage-opt dm.use_deferred_removal=true

--- a/pebbles/drivers/provisioning/docker_driver.py
+++ b/pebbles/drivers/provisioning/docker_driver.py
@@ -342,6 +342,8 @@ class DockerDriverAccessProxy(object):
             logger.debug('UNREACHABLE HOSTS ' + str(pb_executor._unreachable_hosts))
         if getattr(pb_executor, '_failed_hosts', False):
             logger.debug('FAILED_HOSTS ' + str(pb_executor._failed_hosts))
+
+        if not run_success:
             raise RuntimeError('run_ansible_on_host(%s) failed' % host['id'])
         logger.debug('_prepare_host():  done running ansible')
 


### PR DESCRIPTION
The default storage backend for Docker on CentOS is overlay2 since
some time already. Switch to using that by formatting docker storage
volume as xfs, mounting it to /var/lib/docker and using the default
storage configuration.

Also fix error detection in preparing pool VM, where unreachable host
would pass without error.
